### PR TITLE
Bug fix for issue 128, plus useful extensions

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -26,7 +26,7 @@ class Thor
     # usage<String>:: Short usage for the subcommand
     # description<String>:: Description for the subcommand
     def register(klass, subcommand_name, usage, description, options={})
-      if klass <= Thor::Group
+      if Thor.const_defined?(:Group) && klass <= Thor::Group
         desc usage, description, options
         define_method(subcommand_name) { invoke klass }
       else

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -199,9 +199,14 @@ class Thor
     def subcommands
       @subcommands ||= from_superclass(:subcommands, [])
     end
+    
+    def parent_commands
+      @parent_commands ||= from_superclass(:parent_commands, [])
+    end
 
     def subcommand(subcommand, subcommand_class)
       self.subcommands << subcommand.to_s
+      subcommand_class.parent_commands << subcommand.to_s
       subcommand_class.subcommand_help subcommand
       define_method(subcommand) { |*args| invoke subcommand_class, args }
     end

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -2,6 +2,15 @@ require 'thor/base'
 
 class Thor
   class << self
+    # Sets a banner for the class as a whole
+    #
+    # ==== Parameters
+    # text<String>:: The banner text
+    #
+    def banner(text)
+      @class_banner = text
+    end
+    
     # Sets the default task when thor is executed without an explicit task to be called.
     #
     # ==== Parameters
@@ -156,7 +165,7 @@ class Thor
       handle_no_task_error(meth) unless task
 
       shell.say "Usage:"
-      shell.say "  #{banner(task)}"
+      shell.say "  #{task_banner(task)}"
       shell.say
       class_options_help(shell, nil => task.options.map { |_, o| o })
       if task.long_description
@@ -173,6 +182,7 @@ class Thor
     # shell<Thor::Shell>
     #
     def help(shell, subcommand = false)
+      shell.say @class_banner if @class_banner
       list = printable_tasks(true, subcommand)
       Thor::Util.thor_classes_in(self).each do |klass|
         list += klass.printable_tasks(false)
@@ -190,7 +200,7 @@ class Thor
       (all ? all_tasks : tasks).map do |_, task|
         next if task.hidden?
         item = []
-        item << banner(task, false, subcommand)
+        item << task_banner(task, false, subcommand)
         item << (task.description ? "# #{task.description.gsub(/\s+/m,' ')}" : "")
         item
       end.compact
@@ -269,12 +279,12 @@ class Thor
         new(args, opts, config).invoke_task(task, trailing || [])
       end
 
-      # The banner for this class. You can customize it if you are invoking the
+      # The banner for a task. You can customize it if you are invoking the
       # thor class by another ways which is not the Thor::Runner. It receives
       # the task that is going to be invoked and a boolean which indicates if
       # the namespace should be displayed as arguments.
       #
-      def banner(task, namespace = nil, subcommand = false)
+      def task_banner(task, namespace = nil, subcommand = false)
         "#{basename} #{task.formatted_usage(self, $thor_runner, subcommand)}"
       end
 

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -294,8 +294,13 @@ class Thor
         elsif @default_task && @default_task_allows_args
           meth = @default_task
           task = all_tasks[normalize_task_name(meth)]
-          given_args = original_args # Restore original arguments (meth has been popped above)
-          args, opts = Thor::Options.split(given_args)
+          if task
+            given_args = original_args # Restore original arguments (meth has been popped above)
+            args, opts = Thor::Options.split(given_args)
+          else # Default task not found
+            args, opts = given_args, nil
+            task = Thor::DynamicTask.new(meth)
+          end
         else
           args, opts = given_args, nil
           task = Thor::DynamicTask.new(meth)

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -53,6 +53,7 @@ class Thor
     end
 
     # Defines the long description of the next task.
+    # Note: Thor normally wraps the long description. See Thor::Basic#print_wrapped for options
     #
     # ==== Parameters
     # long description<String>

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -414,7 +414,7 @@ class Thor
       end
 
       def handle_argument_error(task, error) #:nodoc:
-        raise InvocationError, "#{task.name.inspect} was called incorrectly. Call as #{self.banner(task).inspect}."
+        raise InvocationError, "#{task.name.inspect} was called incorrectly. Call as #{self.task_banner(task).inspect}."
       end
 
       protected

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -471,9 +471,13 @@ class Thor
         # name<Symbol>:: The name of the argument.
         # options<Hash>:: Described in both class_option and method_option.
         def build_option(name, options, scope) #:nodoc:
+          if options[:repeats]
+            options = options.merge(:default=>[])
+          end
           scope[name] = Thor::Option.new(name, options[:desc], options[:required],
                                                options[:type], options[:default], options[:banner],
-                                               options[:lazy_default], options[:group], options[:aliases])
+                                               options[:lazy_default], options[:group], options[:aliases], 
+                                               options[:repeats])
         end
 
         # Receives a hash of options, parse them and add to the scope. This is a

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -203,6 +203,10 @@ class Thor::Group
       item << (desc ? "# #{desc.gsub(/\s+/m,' ')}" : "")
       [item]
     end
+    
+    def parent_commands
+      []
+    end
 
     def handle_argument_error(task, error) #:nodoc:
       raise error, "#{task.name.inspect} was called incorrectly. Are you sure it has arity equals to 0?"

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -174,7 +174,7 @@ class Thor::Group
       invocations.each do |name, from_option|
         value = if from_option
           option = class_options[name]
-          option.type == :boolean ? name : option.default
+          option.type == :boolean ? name : (option.default.dup rescue option.default)
         else
           name
         end

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -29,7 +29,7 @@ class Thor
 
       arguments.each do |argument|
         if argument.default != nil
-          @assigns[argument.human_name] = argument.default
+          @assigns[argument.human_name] = (argument.default.dup rescue argument.default)
         elsif argument.required?
           @non_assigned_required << argument
         end

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -1,14 +1,15 @@
 class Thor
   class Option < Argument #:nodoc:
-    attr_reader :aliases, :group, :lazy_default
+    attr_reader :aliases, :group, :lazy_default, :repeats
 
     VALID_TYPES = [:boolean, :numeric, :hash, :array, :string]
 
-    def initialize(name, description=nil, required=nil, type=nil, default=nil, banner=nil, lazy_default=nil, group=nil, aliases=nil)
+    def initialize(name, description=nil, required=nil, type=nil, default=nil, banner=nil, lazy_default=nil, group=nil, aliases=nil, repeats=nil)
       super(name, description, required, type, default, banner)
       @lazy_default = lazy_default
       @group        = group.to_s.capitalize if group
       @aliases      = [*aliases].compact
+      @repeats      = repeats
     end
 
     # This parse quick options given as method_options. It makes several
@@ -64,7 +65,7 @@ class Thor
         value.class.name.downcase.to_sym
       end
 
-      self.new(name.to_s, nil, required, type, default, nil, nil, nil, aliases)
+      self.new(name.to_s, nil, required, type, default, nil, nil, nil, aliases, nil)
     end
 
     def switch_name

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -69,7 +69,12 @@ class Thor
 
           switch = normalize_switch(switch)
           option = switch_option(switch)
-          @assigns[option.human_name] = parse_peek(switch, option)
+          if option.repeats
+            @assigns[option.human_name] ||= []
+            @assigns[option.human_name] << parse_peek(switch,option)
+          else
+            @assigns[option.human_name] = parse_peek(switch, option)
+          end
         elsif match
           @unknown << shift
         else

--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -156,7 +156,7 @@ class Thor::Runner < Thor #:nodoc:
 
   private
 
-    def self.banner(task, all = false, subcommand = false)
+    def self.task_banner(task, all = false, subcommand = false)
       "thor " + task.formatted_usage(self, all, subcommand)
     end
 

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -133,7 +133,12 @@ class Thor
       end
 
       # Prints a long string, word-wrapping the text to the current width of the
-      # terminal display. Ideal for printing heredocs.
+      # terminal display. "\n\n" forces a paragraph break. Ideal for printing heredocs.
+      #
+      # If you want to override this wrapping behavior (e.g. for printing tables),
+      # the following tricks work:
+      # "\005" forces a single line break
+      # "\177" is a non-breaking and non-squeezed space
       #
       # ==== Parameters
       # String
@@ -148,8 +153,8 @@ class Thor
 
         paras.map! do |unwrapped|
           unwrapped.strip.gsub(/\n/, " ").squeeze(" ").
-          gsub(/.{1,#{width}}(?:\s|\Z)/){($& + 5.chr).
-          gsub(/\n\005/,"\n").gsub(/\005/,"\n")}
+          gsub(/.{1,#{width}}(?:\s|\Z)/){($& + 5.chr)}.
+          gsub(/\n\005/,"\n").gsub(/\005/,"\n")
         end
 
         paras.each do |para|

--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -39,6 +39,9 @@ class Thor
 
       formatted ||= ""
 
+      # Add parent commands (for subcommands)
+      klass.parent_commands.each {|parent_command| formatted << parent_command + ' ' }
+
       # Add usage with required arguments
       formatted << if klass && !klass.arguments.empty?
         usage.to_s.gsub(/^#{name}/) do |match|

--- a/lib/thor/task.rb
+++ b/lib/thor/task.rb
@@ -106,7 +106,9 @@ class Thor
     end
 
     def run(instance, args=[])
-      if (instance.methods & [name.to_s, name.to_sym]).empty?
+      if name == '' # Missing task -- probably misnamed default task
+        instance.class.handle_no_task_error(instance.class.default_task)
+      elsif (instance.methods & [name.to_s, name.to_sym]).empty?
         super
       else
         instance.class.handle_no_task_error(name)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -178,7 +178,7 @@ describe Thor::Base do
       Thor::Base.subclass_files[File.expand_path(thorfile)].should == [
         MyScript, MyScript::AnotherScript, MyChildScript, Barn,
         Scripts::MyScript, Scripts::MyDefaults, Scripts::ChildDefault,
-        WithArgsOnDefaultTask
+        WithArgsOnDefaultTask, WithBadDefaultTask
       ]
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -177,7 +177,8 @@ describe Thor::Base do
       thorfile = File.join(File.dirname(__FILE__), "fixtures", "script.thor")
       Thor::Base.subclass_files[File.expand_path(thorfile)].should == [
         MyScript, MyScript::AnotherScript, MyChildScript, Barn,
-        Scripts::MyScript, Scripts::MyDefaults, Scripts::ChildDefault
+        Scripts::MyScript, Scripts::MyDefaults, Scripts::ChildDefault,
+        WithArgsOnDefaultTask
       ]
     end
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -184,3 +184,22 @@ module Scripts
   end
 end
 
+class WithArgsOnDefaultTask < Thor
+  default_task :example_default_task, :args=>true
+  
+  banner "MyScript does really cool stuff"
+
+  map "-T" => :animal, ["-f", "--foo"] => :foo
+
+  desc "zoo", "zoo around"
+  def zoo
+    "zoo"
+  end
+
+  desc "example_default_task", "example!"
+  method_options :with => :string
+  def example_default_task(*args)
+    ["default task", options, args]
+  end
+end
+

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -7,6 +7,8 @@ class MyScript < Thor
 
   group :script
   default_task :example_default_task
+  
+  banner "MyScript does really cool stuff"
 
   map "-T" => :animal, ["-f", "--foo"] => :foo
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -203,3 +203,22 @@ class WithArgsOnDefaultTask < Thor
   end
 end
 
+class WithBadDefaultTask < Thor
+  default_task :bad_default_task
+
+  banner "MyScript does really cool stuff"
+
+  map "-T" => :animal, ["-f", "--foo"] => :foo
+
+  desc "zoo", "zoo around"
+  def zoo
+    "zoo"
+  end
+
+  desc "example_default_task", "example!"
+  method_options :with => :string
+  def example_default_task(*args)
+    ["default task", options, args]
+  end
+end
+

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -83,6 +83,13 @@ END
     [ name, options ]
   end
 
+  method_option :repeater, :type=>:string, :default=>'foo', :repeats=>true
+  method_option :other, :type=>:boolean
+  desc "with_repeater NAME", "invoke with optional name"
+  def with_repeater(name=nil)
+    [ name, options ]
+  end
+
   class AnotherScript < Thor
     desc "baz", "do some bazing"
     def baz

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -13,18 +13,21 @@ describe Thor::Task do
     it "includes namespace within usage" do
       Object.stub!(:namespace).and_return("foo")
       Object.stub!(:arguments).and_return([])
+      Object.stub!(:parent_commands).and_return([])
       task(:bar => :required).formatted_usage(Object).should == "foo:can_has --bar=BAR"
     end
 
     it "removes default from namespace" do
       Object.stub!(:namespace).and_return("default:foo")
       Object.stub!(:arguments).and_return([])
+      Object.stub!(:parent_commands).and_return([])
       task(:bar => :required).formatted_usage(Object).should == ":foo:can_has --bar=BAR"
     end
 
     it "injects arguments into usage" do
       Object.stub!(:namespace).and_return("foo")
       Object.stub!(:arguments).and_return([ Thor::Argument.new(:bar, nil, true, :string) ])
+      Object.stub!(:parent_commands).and_return([])
       task(:foo => :required).formatted_usage(Object).should == "foo:can_has BAR --foo=FOO"
     end
   end

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -89,6 +89,32 @@ describe Thor do
     end
   end
 
+  describe "#default_task_with_args_allowed" do
+    it "sets a default task" do
+      WithArgsOnDefaultTask.default_task.should == "example_default_task"
+    end
+
+    it "invokes the default task if no command is specified" do
+      WithArgsOnDefaultTask.start([]).first.should == "default task"
+    end
+
+    it "invokes the default task if no command is specified even if switches are given" do
+      WithArgsOnDefaultTask.start(["--with", "option"])[1].should == {"with"=>"option"}
+    end
+
+    it "invokes the default task if no command is specified even if arguments are given" do
+      WithArgsOnDefaultTask.start(["foo", "bar"]).first.should == "default task"
+    end
+
+    it "passes arguments to the default task" do
+      WithArgsOnDefaultTask.start(["foo", "bar"]).last.should == ["foo", "bar"]
+    end
+
+    it "invokes other defined commands properly" do
+      WithArgsOnDefaultTask.start(["zoo"]).should == "zoo"
+    end
+  end
+
   describe "#map" do
     it "calls the alias of a method if one is provided" do
       MyScript.start(["-T", "fish"]).should == ["fish"]

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -47,6 +47,23 @@ describe Thor do
       end
     end
 
+    describe ":repeats" do
+      it "returns [] if no values are given" do
+        arg, options = MyScript.start(["with_repeater"])
+        options.should == {"repeater"=>[]}
+      end
+
+      it "returns a single value" do
+        arg, options = MyScript.start(["with_repeater", "--repeater", "baz"])
+        options.should == {"repeater"=>["baz"]}
+      end
+
+      it "returns multiple values" do
+        arg, options = MyScript.start(["with_repeater", "--repeater", "foo", "--other", "--repeater", "bar"])
+        options.should == {"repeater"=>["foo", "bar"], "other"=>true}
+      end
+    end
+
     describe "when :for is supplied" do
       it "updates an already defined task" do
         args, options = MyChildScript.start(["animal", "horse", "--other=fish"])

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -102,8 +102,15 @@ describe Thor do
     it "inherits all mappings from parent" do
       MyChildScript.default_task.should == "example_default_task"
     end
-  end
 
+  end
+  describe "#banner" do
+    it "includes a class banner" do
+      content = capture(:stdout) { MyScript.start(["help"]) }
+      content.should =~ /MyScript does really cool stuff/m
+    end
+  end
+      
   describe "#desc" do
     it "provides description for a task" do
       content = capture(:stdout) { MyScript.start(["help"]) }

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -115,6 +115,15 @@ describe Thor do
     end
   end
 
+  describe "#bad_default_task" do
+    it "calls method missing if no command is specified" do
+      content = capture(:stderr){
+        WithBadDefaultTask.start([])
+      }
+      content.strip.should == 'Could not find task "bad_default_task" in "with_bad_default_task" namespace.'
+    end
+  end
+
   describe "#map" do
     it "calls the alias of a method if one is provided" do
       MyScript.start(["-T", "fish"]).should == ["fish"]


### PR DESCRIPTION
This replaces pull request at issue 143. It includes a bug fix for issue 128 and some changes to add a few capabilities I've found helpful:
- Adds a banner method for a Thor class (not just a banner for an individual task)
- Allows default tasks to take arguments (so, if the class foo has default task bar and the user specifies thor foo plugh where plugh is not a recognized task, it is interpreted as thor foo bar plugh
- Improve error-handling if the default task is not found (e.g. if default_task :chewbacca is specified, but there is no "chewbacca" task)
- Fixes the bug in Issue 128 related to listing subcommands (and replaces the patch I submitted as Issue 137). The fix is in commit 0726f56723b36df148ace0de7fcf47c04d981a78
- Allows for repeating options, e.g. thor class task -r file1 -r file2
- Fixes a small bug in print_wrapped (occasionally did not handle \005 and \177 correctly)

This fixes the bugs in the original submission of this patch It passes all tests ONCE YOU FIX THE BUG identified in issue 144. See my patch submitted separately as issue 146.

Thanks again to everyone else whose work made Thor so terrific.
