### PR TITLE
Failing test for Help method in Thor class with an Argument

### DIFF
--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -176,7 +176,7 @@ describe Thor::Base do
     it "returns tracked subclasses, grouped by the files they come from" do
       thorfile = File.join(File.dirname(__FILE__), "fixtures", "script.thor")
       Thor::Base.subclass_files[File.expand_path(thorfile)].should == [
-        MyScript, MyScript::AnotherScript, MyChildScript, Barn,
+        MyScript, MyScript::AnotherScript, MyChildScript, Barn, MyScriptWithAnArgument,
         Scripts::MyScript, Scripts::MyDefaults, Scripts::ChildDefault
       ]
     end

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -154,6 +154,14 @@ class Barn < Thor
 
 end
 
+class MyScriptWithAnArgument < Thor
+  argument :food, :type => :string
+  desc "throw", "throw food into the monkey cage"
+  def throw
+    puts "don't feed #{food} to the monkeys"
+  end
+end
+
 module Scripts
   class MyScript < MyChildScript
     argument :accessor, :type => :string

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -339,6 +339,11 @@ HELP
         capture(:stdout){ MyScript.start(["help", "foo"]) }.should =~ /Usage:/
       end
     end
+    describe "with argument" do
+      it "calls the class method" do
+        capture(:stdout){ MyScriptWithAnArgument.start(["help", "throw"]) }.should =~ /Usage:/
+      end
+    end
   end
 
   describe "when creating tasks" do


### PR DESCRIPTION
I was looking into http://stackoverflow.com/questions/11040420/thor-how-can-i-get-my-thor-task-to-display-help-when-i-have-defined-an-argumen, and it seems like there's an actual bug in Thor here.

For the Thor Classes:

``` ruby
class Ok < Thor
    desc "foo", "This should be the description for foo"
    def foo
        puts "in a.thor ok:foo\n"
    end
end
class Broke < Thor
    argument :arg1, :type=>:string, :desc => "arg1"    
    desc "foo", "This should be the description for foo"
    def foo
        puts "in a.thor broke:foo arg1=#{self.arg1}\n"
    end
end
```

`thor help ok: foo` returns:

```
Usage:
  thor ok:foo

This should be the description for foo
```

but `thor help broke:foo` returns:

```
Tasks:
  thor broke:foo ARG1          # This should be the description for foo
  thor broke:help ARG1 [TASK]  # Describe available tasks or one specific task
```

I've a little time trying to figure out what's happening, and it looks like since there's a named argument, in `#initialize` in `base.rb`, the second time it runs (not for Thor::Runner, but for the actual class), it assigns the method name to the named argument, eating it instead of passing it through to the `help` method.

I've attached a failing test—at this point, I haven't figured out how to solve it yet, but thought this might help.
