### PR TITLE
Possible fix for the subcommand help messages using the klass name instead of command name

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -454,7 +454,11 @@ class Thor
 
     def subcommand_help(cmd)
       desc "help [COMMAND]", "Describe subcommands or one specific subcommand"
-      class_eval <<-RUBY
+      class_eval <<-RUBY 
+        @subcommand_name = "#{cmd.to_s}"
+        def self.subcommand_name()
+          @subcommand_name
+        end
         def help(command = nil, subcommand = true); super; end
       RUBY
     end

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -45,7 +45,8 @@ class Thor
         namespace = klass.namespace
         formatted = "#{namespace.gsub(/^(default)/,'')}:"
       end
-      formatted = "#{klass.namespace.split(':').last} " if subcommand
+      
+      formatted = (klass.respond_to? :subcommand_name) ? "#{klass.subcommand_name} " : "#{klass.namespace.split(':').last} " if subcommand
 
       formatted ||= ""
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -192,7 +192,7 @@ describe Thor::Base do
     it "returns tracked subclasses, grouped by the files they come from" do
       thorfile = File.join(File.dirname(__FILE__), "fixtures", "script.thor")
       expect(Thor::Base.subclass_files[File.expand_path(thorfile)]).to eq([
-        MyScript, MyScript::AnotherScript, MyChildScript, Barn,
+        MyScript, MyScript::AnotherScript, MyChildScript, BarnCli,
         PackageNameScript, Scripts::MyScript, Scripts::MyDefaults,
         Scripts::ChildDefault, Scripts::Arities
       ])

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -145,7 +145,7 @@ class MyChildScript < MyScript
   remove_command :boom, :undefine => true
 end
 
-class Barn < Thor
+class BarnCli < Thor
   desc "open [ITEM]", "open the barn door"
   def open(item = nil)
     if item == "shotgun"
@@ -192,7 +192,7 @@ module Scripts
     end
 
     desc "barn", "commands to manage the barn"
-    subcommand "barn", Barn
+    subcommand "barn", BarnCli
   end
 
   class ChildDefault < Thor

--- a/spec/register_spec.rb
+++ b/spec/register_spec.rb
@@ -157,7 +157,7 @@ describe ".register-ing a Thor subclass" do
       begin
         $thor_runner = false
         help_output = capture(:stdout) { BoringVendorProvidedCLI.start(%w[exciting]) }
-        expect(help_output).to include('thor exciting_plugin_c_l_i fireworks')
+        expect(help_output).to include('thor exciting fireworks')
       ensure
         $thor_runner = true
       end

--- a/spec/subcommand_spec.rb
+++ b/spec/subcommand_spec.rb
@@ -6,7 +6,7 @@ describe Thor do
 
     it "maps a given subcommand to another Thor subclass" do
       barn_help = capture(:stdout) { Scripts::MyDefaults.start(%w[barn]) }
-      expect(barn_help).to include("barn help [COMMAND]  # Describe subcommands or one specific subcommand")
+      expect(barn_help).to include("thor barn help [COMMAND]  # Describe subcommands or one specific subcommand")
     end
 
     it "passes commands to subcommand classes" do


### PR DESCRIPTION
Changed spec/subcommand and spec/fixtures/script.thor to expose the problem of when the subcommand name is different than the klass.

Fixed it by:

Updating lib/thor.rb metaprogramming magic that adds the help methods
to the subcommand klass to include a class instance variable that is
initialized to the subcommand_name and a method to access it.

Then modified command#formatted_usage to make use of that method if
its processing a subcommand and the subcommand_method exists.

Also had to "fix" the spec/register_spec.rb
   context "when $thor_runner is false"
that had a test that seemed to accecpt the fact that subcommand names
got foobar'd if the klass name is different than the subcommand name.
Or I didn't understand that test, but I changed it to what made more
sense to me.

I believe this addresses #306, #169, #170, #196, #261, #128, #288
