### PR TITLE
Use custom print method for printing defaults.

### DIFF
--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -518,7 +518,7 @@ class Thor
             item.push(option.description ? "# #{option.description}" : "")
 
             list << item
-            list << ["", "# Default: #{option.default}"] if option.show_default?
+            list << ["", "# Default: #{option.print_default}"] if option.show_default?
             list << ["", "# Possible values: #{option.enum.join(', ')}"] if option.enum
           end
         end

--- a/lib/thor/parser/argument.rb
+++ b/lib/thor/parser/argument.rb
@@ -24,6 +24,17 @@ class Thor
       validate! # Trigger specific validations
     end
 
+    def print_default
+      if @type == :array and @default.is_a?(Array)
+        @default.map { |x|
+          p = x.gsub('"','\\"')
+          "\"#{p}\""
+        }.join(" ")
+      else
+        @default
+      end
+    end
+
     def usage
       required? ? banner : "[#{banner}]"
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -131,6 +131,10 @@ describe Thor::Base do
       expect(@content).to match(/# Default: 3/)
     end
 
+    it "prints arrays as copy pasteables" do
+      expect(@content).to match(/Default: "foo" "bar"/)
+    end
+
     it "shows options in different groups" do
       expect(@content).to match(/Options\:/)
       expect(@content).to match(/Runtime options\:/)

--- a/spec/fixtures/group.thor
+++ b/spec/fixtures/group.thor
@@ -17,6 +17,7 @@ class MyCounter < Thor::Group
   class_option :fourth,   :type => :numeric, :desc => "The fourth argument"
   class_option :simple,   :type => :numeric, :aliases => 'z'
   class_option :symbolic, :type => :numeric, :aliases => [:y, :r]
+  class_option :array,    :type => :array, :default => ['foo','bar']
 
   desc <<-FOO
 Description:

--- a/spec/parser/argument_spec.rb
+++ b/spec/parser/argument_spec.rb
@@ -50,4 +50,28 @@ describe Thor::Argument do
       expect(argument(:foo, :type => :hash).usage).to eq("key:value")
     end
   end
+
+  describe "#print_default" do
+    it "prints arrays in a copy pasteable way" do
+      expect(argument(:foo, {
+        :required => false,
+        :type     => :array,
+        :default  => ['one','two']
+      }).print_default).to eq('"one" "two"')
+    end
+    it "prints arrays with a single string default as before" do
+      expect(argument(:foo,    {
+        :required => false,
+        :type     => :array,
+        :default  => 'foobar'
+      }).print_default).to eq('foobar')
+    end
+    it "prints none arrays as default" do
+      expect(argument(:foo, {
+        :required => false,
+        :type     => :numeric,
+        :default  => 13,
+      }).print_default).to eq(13)
+    end
+  end
 end


### PR DESCRIPTION
Prints default arrays in a copy paste able way.

Difference in output:

Old:

```
Options:
  [--ignore-files=one two three]
                                       # Default: ["**/spec/**/*.pp", "**/tests/**/*.pp", "**/example/**/*.pp"]
  [--disable-manifests=one two three]
                                       # Default: autoloader_layout
```

New:

```
Options:
  [--ignore-files=one two three]
                                        # Default: "**/spec/**/*.pp" "**/tests/**/*.pp" "**/example/**/*.pp"
  [--disable-manifests=one two three]
                                       # Default: autoloader_layout
  [--verbose], [--no-verbose]
```
