### PR TITLE
Add a new feature for exclusive options and required at_least_one option

### DIFF
--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -1,14 +1,15 @@
 class Thor
-  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :disable_class_options)
+  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :disable_class_options, :options_relation)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
-    def initialize(name, description, long_description, usage, options = nil, disable_class_options = false)
-      super(name.to_s, description, long_description, usage, options || {}, disable_class_options)
+    def initialize(name, description, long_description, usage, options = nil, disable_class_options = false, options_relation = nil)
+      super(name.to_s, description, long_description, usage, options || {}, disable_class_options, options_relation || {})
     end
 
     def initialize_copy(other) #:nodoc:
       super(other)
       self.options = other.options.dup if other.options
+      self.options_relation = other.options_relation.dup if other.options_relation
     end
 
     def hidden?
@@ -62,6 +63,12 @@ class Thor
       # Strip and go!
       formatted.strip
     end
+    def method_exclusive_option_names
+      self.options_relation[:exclusive_option_names] || []
+    end
+    def method_at_least_one_option_names
+      self.options_relation[:at_least_one_option_names] || []
+    end
 
   protected
 
@@ -72,7 +79,6 @@ class Thor
     def required_options
       @required_options ||= options.map { |_, o| o.usage if o.required? }.compact.sort.join(" ")
     end
-
     # Given a target, checks if this class name is a public method.
     def public_method?(instance) #:nodoc:
       !(instance.public_methods & [name.to_s, name.to_sym]).empty?

--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -29,4 +29,10 @@ class Thor
 
   class MalformattedArgumentError < InvocationError
   end
+
+  class ExclusiveArgumentError < InvocationError
+  end
+
+  class AtLeastOneRequiredArgumentError < InvocationError
+  end
 end

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -29,8 +29,10 @@ class Thor
     #
     # If +stop_on_unknown+ is true, #parse will stop as soon as it encounters
     # an unknown option or a regular argument.
-    def initialize(hash_options = {}, defaults = {}, stop_on_unknown = false)
+    def initialize(hash_options = {}, defaults = {}, stop_on_unknown = false, relations = {})
       @stop_on_unknown = stop_on_unknown
+      @exclusives = (relations[:exclusive_option_names] || []).select{|array| !array.empty?}
+      @at_least_ones = (relations[:at_least_one_option_names] || []).select{|array| !array.empty?}
       options = hash_options.values
       super(options)
 
@@ -110,10 +112,35 @@ class Thor
       end
 
       check_requirement!
+      check_exclusive!
+      check_at_least_one!
 
       assigns = Thor::CoreExt::HashWithIndifferentAccess.new(@assigns)
       assigns.freeze
       assigns
+    end
+
+    def check_exclusive!
+      opts = @assigns.keys
+      # When option A and B are exclusive, if A and B are given at the same time,
+      # the diffrence of argument array size will decrease.
+      found = @exclusives.find{ |ex| (ex - opts).size < ex.size - 1 }
+      if found
+        names = names_to_switch_names(found & opts).map{|n| "'#{n}'"}
+        class_name = self.class.name.split("::").last.downcase
+        fail ExclusiveArgumentError, "Found exclusive #{class_name} #{names.join(", ")}"
+      end
+    end
+    def check_at_least_one!
+      opts = @assigns.keys
+      # When at least one is required of the options A and B,
+      # if the both options were not given, none? would be true.
+      found = @at_least_ones.find{ |one_reqs| one_reqs.none?{ |o| opts.include? o} }
+      if found
+        names = names_to_switch_names(found).map{|n| "'#{n}'"}
+        class_name = self.class.name.split("::").last.downcase
+        fail AtLeastOneRequiredArgumentError, "Not found at least one of required #{class_name} #{names.join(", ")}"
+      end
     end
 
     def check_unknown!
@@ -123,6 +150,16 @@ class Thor
     end
 
   protected
+    # Option names changes to swith name or human name
+    def names_to_switch_names(names = [])
+      @switches.map do |_, o|
+        if names.include? o.name
+          o.respond_to?(:switch_name) ? o.switch_name : o.human_name
+        else
+          nil
+        end
+      end.compact
+    end
 
     # Check if the current value in peek is a registered switch.
     #

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -69,6 +69,48 @@ describe Thor::Base do
     end
   end
 
+  describe "#class_exclusive_option_names" do
+    it "returns the exclusive option names for the class" do
+      expect(MyClassOptionScript.class_exclusive_option_names.size).to be(1)
+      expect(MyClassOptionScript.class_exclusive_option_names.first.size).to be(2)
+    end
+  end
+  describe "#class_at_least_one_option_names" do
+    it "returns the at least one of option names for the class" do
+      expect(MyClassOptionScript.class_at_least_one_option_names.size).to be(1)
+      expect(MyClassOptionScript.class_at_least_one_option_names.first.size).to be(2)
+    end
+  end
+  describe "#class_exclusive" do
+    it "raise error when exclusive options are given" do
+      begin
+        ENV["THOR_DEBUG"] = "1"
+        expect do
+          MyClassOptionScript.start %w[mix --one --two --three --five]
+        end.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--one', '--two'")
+        expect do
+          MyClassOptionScript.start %w[mix --one --three --five --six]
+        end.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--five', '--six'")
+      ensure
+        ENV["THOR_DEBUG"] = nil
+      end
+    end
+  end
+  describe "#class_at_least_one" do
+    it "raise error when at least one of required options are not given" do
+      begin
+        ENV["THOR_DEBUG"] = "1"
+        expect do
+          MyClassOptionScript.start %w[mix --five]
+        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--three', '--four'")
+        expect do
+          MyClassOptionScript.start %w[mix --one --three]
+        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--five', '--six', '--seven'")
+      ensure
+        ENV["THOR_DEBUG"] = nil
+      end
+    end
+  end
   describe ":aliases" do
     it "supports string aliases without a dash prefix" do
       expect(MyCounter.start(%w[1 2 -z 3])[4]).to eq(3)
@@ -96,6 +138,7 @@ describe Thor::Base do
       expect(options[:force]).not_to be_required
     end
   end
+
 
   describe "#remove_argument" do
     it "removes previously defined arguments from class" do
@@ -194,7 +237,7 @@ describe Thor::Base do
       expect(Thor::Base.subclass_files[File.expand_path(thorfile)]).to eq([
         MyScript, MyScript::AnotherScript, MyChildScript, Barn,
         PackageNameScript, Scripts::MyScript, Scripts::MyDefaults,
-        Scripts::ChildDefault, Scripts::Arities
+        Scripts::ChildDefault, Scripts::Arities, MyClassOptionScript, MyOptionScript
       ])
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -85,12 +85,15 @@ describe Thor::Base do
     it "raise error when exclusive options are given" do
       begin
         ENV["THOR_DEBUG"] = "1"
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Found exclusive options '--one', '--two'"
+
         expect do
           MyClassOptionScript.start %w[mix --one --two --three --five]
-        end.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--one', '--two'")
+        end.to raise_error(Thor::ExclusiveArgumentError, err_msg)
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Found exclusive options '--five', '--six'"
         expect do
           MyClassOptionScript.start %w[mix --one --three --five --six]
-        end.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--five', '--six'")
+        end.to raise_error(Thor::ExclusiveArgumentError, err_msg)
       ensure
         ENV["THOR_DEBUG"] = nil
       end
@@ -100,12 +103,14 @@ describe Thor::Base do
     it "raise error when at least one of required options are not given" do
       begin
         ENV["THOR_DEBUG"] = "1"
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Not found at least one of required options '--three', '--four'"
         expect do
           MyClassOptionScript.start %w[mix --five]
-        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--three', '--four'")
+        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, err_msg)
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Not found at least one of required options '--five', '--six', '--seven'"
         expect do
           MyClassOptionScript.start %w[mix --one --three]
-        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--five', '--six', '--seven'")
+        end.to raise_error(Thor::AtLeastOneRequiredArgumentError, err_msg)
       ensure
         ENV["THOR_DEBUG"] = nil
       end

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -218,3 +218,71 @@ module Scripts
   end
 end
 
+class MyClassOptionScript < Thor
+  class_option :free
+
+	class_exclusive do
+	  class_option :one
+	  class_option :two
+	end
+
+	class_at_least_one do
+	  class_option :three
+	  class_option :four
+	end
+  desc "mix", ""
+  exclusive do
+    at_least_one do
+      option :five
+      option :six
+      option :seven
+    end
+  end
+  def mix
+  end
+end
+class MyOptionScript < Thor
+  desc "exclusive", ""
+  exclusive do
+    method_option :one
+    method_option :two
+    method_option :three
+  end
+  method_option :after1
+  method_option :after2
+  def exclusive
+
+	end
+	exclusive :after1, :after2, {:for => :exclusive}
+
+  desc "at_least_one", ""
+	at_least_one do
+	  method_option :one
+	  method_option :two
+	  method_option :three
+	end
+  method_option :after1
+  method_option :after2
+  def at_least_one
+
+	end
+  at_least_one :after1, :after2, :for => :at_least_one
+
+  desc "only_one", ""
+  exclusive do
+    at_least_one do
+      option :one
+      option :two
+      option :three
+    end
+  end
+  def only_one
+  end
+
+	desc "no_relastions", ""
+	option :no_rel1
+	option :no_rel2
+	def no_relations
+
+	end	
+end

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -253,7 +253,8 @@ describe Thor::Options do
       end
 
       it "raises an error if exclusive argumets are given" do
-        expect{parse(%w[--foo --bar])}.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--foo', '--bar'")
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Found exclusive options '--foo', '--bar'"
+        expect{parse(%w[--foo --bar])}.to raise_error(Thor::ExclusiveArgumentError, err_msg)
       end
 
       it "does not raise an error if exclusive argumets are not given" do
@@ -268,7 +269,8 @@ describe Thor::Options do
       end
 
       it "raises an error if at least one of required argumet is not given" do
-        expect{parse(%w[--baz])}.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--foo', '--bar'")
+        err_msg = RUBY_VERSION < '1.9.2' ? nil : "Not found at least one of required options '--foo', '--bar'"
+        expect{parse(%w[--baz])}.to raise_error(Thor::AtLeastOneRequiredArgumentError, err_msg)
       end
 
       it "does not raise an error if at least one of required argument is given" do

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -2,12 +2,14 @@ require "helper"
 require "thor/parser"
 
 describe Thor::Options do
-  def create(opts, defaults = {}, stop_on_unknown = false)
+  def create(opts, defaults = {}, stop_on_unknown = false, exclusives = [], at_least_ones = [])
+    relation = {:exclusive_option_names => exclusives,
+      :at_least_one_option_names => at_least_ones}
     opts.each do |key, value|
       opts[key] = Thor::Option.parse(key, value) unless value.is_a?(Thor::Option)
     end
 
-    @opt = Thor::Options.new(opts, defaults, stop_on_unknown)
+    @opt = Thor::Options.new(opts, defaults, stop_on_unknown, relation)
   end
 
   def parse(*args)
@@ -241,6 +243,36 @@ describe Thor::Options do
       it "still interprets everything after -- as args instead of options" do
         expect(parse(%w[-- --verbose])).to eq({})
         expect(remaining).to eq(%w[--verbose])
+      end
+    end
+
+    context "when exclusives is given" do
+      before do
+        create({:foo => :boolean, :bar => :boolean, :baz =>:boolean, :qux => :boolean}, {}, false,
+               [["foo", "bar"], ["baz","qux"]])
+      end
+
+      it "raises an error if exclusive argumets are given" do
+        expect{parse(%w[--foo --bar])}.to raise_error(Thor::ExclusiveArgumentError, "Found exclusive options '--foo', '--bar'")
+      end
+
+      it "does not raise an error if exclusive argumets are not given" do
+        expect{parse(%w[--foo --baz])}.not_to raise_error
+      end
+    end
+
+    context "when at_least_ones is given" do
+      before do
+        create({:foo => :string, :bar => :boolean, :baz =>:boolean, :qux => :boolean}, {}, false,
+               [], [["foo", "bar"], ["baz","qux"]])
+      end
+
+      it "raises an error if at least one of required argumet is not given" do
+        expect{parse(%w[--baz])}.to raise_error(Thor::AtLeastOneRequiredArgumentError, "Not found at least one of required options '--foo', '--bar'")
+      end
+
+      it "does not raise an error if at least one of required argument is given" do
+        expect{parse(%w[--foo --baz])}.not_to raise_error
       end
     end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -241,6 +241,25 @@ describe Thor do
     end
   end
 
+  describe "#method_exclusive" do
+    it "returns the exclusive option names for the class" do
+      cmd =  MyOptionScript.commands["exclusive"]
+      exclusives = cmd.options_relation[:exclusive_option_names]
+      expect(exclusives.size).to be(2)
+      expect(exclusives.first).to eq(%w[one two three])
+      expect(exclusives.last).to eq(%w[after1 after2])
+    end
+  end
+  describe "#method_at_least_one" do
+    it "returns the at least one of option names for the class" do
+      cmd =  MyOptionScript.commands["at_least_one"]
+      at_least_ones = cmd.options_relation[:at_least_one_option_names]
+      expect(at_least_ones.size).to be(2)
+      expect(at_least_ones.first).to eq(%w[one two three])
+      expect(at_least_ones.last).to eq(%w[after1 after2])
+    end
+  end
+
   describe "#start" do
     it "calls a no-param method when no params are passed" do
       expect(MyScript.start(%w[zoo])).to eq(true)
@@ -367,6 +386,26 @@ Usage: "thor scripts:arities:optional_arg [ARG]")
         content = capture(:stdout) { Scripts::MyScript.help(shell) }
         expect(content).to match(/zoo ACCESSOR \-\-param\=PARAM/)
       end
+
+      it "prints class exclusive options" do
+        content = capture(:stdout) { MyClassOptionScript.help(shell) }
+        expect(content).to match(/Exclusive Options:\n\s+--one\s+--two\n/)
+      end
+
+      it "does not print class exclusive options" do
+        content = capture(:stdout) { Scripts::MyScript.help(shell) }
+        expect(content).not_to match(/Exclusive Options:/)
+      end
+
+      it "prints class at least one of requred options" do
+        content = capture(:stdout) { MyClassOptionScript.help(shell) }
+        expect(content).to match(/Required At Least One:\n\s+--three\s+--four\n/)
+      end
+
+      it "does not print class at least one of required options" do
+        content = capture(:stdout) { Scripts::MyScript.help(shell) }
+        expect(content).not_to match(/Required At Least One:/)
+      end
     end
 
     describe "for a specific command" do
@@ -410,6 +449,21 @@ HELP
         expect(capture(:stdout) do
           MyScript.command_help(shell, "name_with_dashes")
         end).not_to match(/so very long/i)
+      end
+
+      it "prints exclusive and at least one options" do
+        message = expect(capture(:stdout) do
+                           MyClassOptionScript.command_help(shell, "mix")
+                         end)
+        message.to match(/Exclusive Options:\n\s+--five\s+--six\s+--seven\n\s+--one\s+--two/)
+        message.to match(/Required At Least One:\n\s+--five\s+--six\s+--seven\n\s+--three\s+--four/)
+      end
+      it "does not print exclusive and at least one options" do
+        message = expect(capture(:stdout) do
+                           MyOptionScript.command_help(shell, "no_relations")
+                         end)
+        message.not_to match(/Exclusive Options:/)
+        message.not_to match(/Rquired At Least One:/)
       end
     end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -246,8 +246,8 @@ describe Thor do
       cmd =  MyOptionScript.commands["exclusive"]
       exclusives = cmd.options_relation[:exclusive_option_names]
       expect(exclusives.size).to be(2)
-      expect(exclusives.first).to eq(%w[one two three])
-      expect(exclusives.last).to eq(%w[after1 after2])
+      expect(exclusives.first.sort).to eq(%w[one two three].sort)
+      expect(exclusives.last.sort).to eq(%w[after1 after2].sort)
     end
   end
   describe "#method_at_least_one" do
@@ -255,8 +255,8 @@ describe Thor do
       cmd =  MyOptionScript.commands["at_least_one"]
       at_least_ones = cmd.options_relation[:at_least_one_option_names]
       expect(at_least_ones.size).to be(2)
-      expect(at_least_ones.first).to eq(%w[one two three])
-      expect(at_least_ones.last).to eq(%w[after1 after2])
+      expect(at_least_ones.first.sort).to eq(%w[one two three].sort)
+      expect(at_least_ones.last.sort).to eq(%w[after1 after2].sort)
     end
   end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -389,7 +389,7 @@ Usage: "thor scripts:arities:optional_arg [ARG]")
 
       it "prints class exclusive options" do
         content = capture(:stdout) { MyClassOptionScript.help(shell) }
-        expect(content).to match(/Exclusive Options:\n\s+--one\s+--two\n/)
+        expect(content).to match(/Exclusive Options:\n\s+--(one|two)\s+--(one|two)\n/)
       end
 
       it "does not print class exclusive options" do
@@ -399,7 +399,7 @@ Usage: "thor scripts:arities:optional_arg [ARG]")
 
       it "prints class at least one of requred options" do
         content = capture(:stdout) { MyClassOptionScript.help(shell) }
-        expect(content).to match(/Required At Least One:\n\s+--three\s+--four\n/)
+        expect(content).to match(/Required At Least One:\n\s+--(three|four)\s+--(three|four)\n/)
       end
 
       it "does not print class at least one of required options" do
@@ -455,8 +455,8 @@ HELP
         message = expect(capture(:stdout) do
                            MyClassOptionScript.command_help(shell, "mix")
                          end)
-        message.to match(/Exclusive Options:\n\s+--five\s+--six\s+--seven\n\s+--one\s+--two/)
-        message.to match(/Required At Least One:\n\s+--five\s+--six\s+--seven\n\s+--three\s+--four/)
+        message.to match(/Exclusive Options:\n\s+--(five|six|seven)\s+--(five|six|seven)\s+--(five|six|seven)\n\s+--(one|two)\s+--(one|two)/)
+        message.to match(/Required At Least One:\n\s+--(five|six|seven)\s+--(five|six|seven)\s+--(five|six|seven)\n\s+--(three|four)\s+--(three|four)/)
       end
       it "does not print exclusive and at least one options" do
         message = expect(capture(:stdout) do


### PR DESCRIPTION
🌈
I've added a new feature for exclusive options and required at least one option.
For exclusive options,

``` ruby
exclusive do
  option :one
  option :two
end
```

You cann't give option `--one` and `--two` at the same time.
If you give wrong options, it shows an error as follows:

```
Found exclusive options '--one`, `--two`
```

For required at least one option:

``` ruby
at_least_one do
  option :three
  option :four
end
```

You must give  at least one option `--three` or `--four`.
This error message:

```
Not found at least one of required options `--three`, `--four`
```

`#class_exclusive` and `#class_at_least_one` methods can be used for `class_option`.
If `#excusive`/`#class_exclusive` or `#at_least_one`/`#class_at_least_one` are defined, the help command show you the relation of options after the`Options:` list as follows:

```
Exclusive Options:
  --one   --two

Required At Least One:
  --three  --four
```
