### PR TITLE
Add validator to method_options with type :string, :numeric, :array and :hash

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -137,14 +137,15 @@ class Thor # rubocop:disable ClassLength
     # options<Hash>:: Described below.
     #
     # ==== Options
-    # :desc     - Description for the argument.
-    # :required - If the argument is required or not.
-    # :default  - Default value for this argument. It cannot be required and have default values.
-    # :aliases  - Aliases for this option.
-    # :type     - The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
-    # :banner   - String to show on usage notes.
-    # :hide     - If you want to hide this option from the help.
-    #
+    # :desc           - Description for the argument.
+    # :required       - If the argument is required or not.
+    # :default        - Default value for this argument. It cannot be required and have default values.
+    # :aliases        - Aliases for this option.
+    # :type           - The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
+    # :banner         - String to show on usage notes.
+    # :hide           - If you want to hide this option from the help.
+    # :validator      - Check value of argument (:string, :array, :numeric), Check key/value of argument (hash). Needs to respond to #call.
+    # :validator_desc - Document which keys/values the validator accepts
     def method_option(name, options = {})
       scope = if options[:for]
         find_and_refresh_command(options[:for]).options

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -195,12 +195,14 @@ class Thor
       # options<Hash>:: Described below.
       #
       # ==== Options
-      # :desc     - Description for the argument.
-      # :required - If the argument is required or not.
-      # :optional - If the argument is optional or not.
-      # :type     - The type of the argument, can be :string, :hash, :array, :numeric.
-      # :default  - Default value for this argument. It cannot be required and have default values.
-      # :banner   - String to show on usage notes.
+      # :desc           - Description for the argument.
+      # :required       - If the argument is required or not.
+      # :optional       - If the argument is optional or not.
+      # :type           - The type of the argument, can be :string, :hash, :array, :numeric.
+      # :default        - Default value for this argument. It cannot be required and have default values.
+      # :banner         - String to show on usage notes.
+      # :validator      - Check value of argument (:string, :array, :numeric), Check key/value of argument (hash). Needs to respond to #call.
+      # :validator_desc - Document which keys/values the validator accepts
       #
       # ==== Errors
       # ArgumentError:: Raised if you supply a required argument after a non required one.
@@ -261,14 +263,16 @@ class Thor
       # options<Hash>:: Described below.
       #
       # ==== Options
-      # :desc::     -- Description for the argument.
-      # :required:: -- If the argument is required or not.
-      # :default::  -- Default value for this argument.
-      # :group::    -- The group for this options. Use by class options to output options in different levels.
-      # :aliases::  -- Aliases for this option. <b>Note:</b> Thor follows a convention of one-dash-one-letter options. Thus aliases like "-something" wouldn't be parsed; use either "\--something" or "-s" instead.
-      # :type::     -- The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
-      # :banner::   -- String to show on usage notes.
-      # :hide::     -- If you want to hide this option from the help.
+      # :desc::           -- Description for the argument.
+      # :required::       -- If the argument is required or not.
+      # :default::        -- Default value for this argument.
+      # :group::          -- The group for this options. Use by class options to output options in different levels.
+      # :aliases::        -- Aliases for this option. <b>Note:</b> Thor follows a convention of one-dash-one-letter options. Thus aliases like "-something" wouldn't be parsed; use either "\--something" or "-s" instead.
+      # :type::           -- The type of the argument, can be :string, :hash, :array, :numeric or :boolean.
+      # :banner::         -- String to show on usage notes.
+      # :hide::           -- If you want to hide this option from the help.
+      # :validator::      -- Check value of argument (:string, :array, :numeric), Check key/value of argument (hash). Needs to respond to #call.
+      # :validator_desc:: -- Document which keys/values the validator accepts
       #
       def class_option(name, options = {})
         build_option(name, options, class_options)

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -524,6 +524,7 @@ class Thor
             list << item
             list << ["", "# Default: #{option.default}"] if option.show_default?
             list << ["", "# Possible values: #{option.enum.join(', ')}"] if option.enum
+            list << ["", "# Validation: #{option.validator_description}"] if option.validator_description
           end
         end
 

--- a/lib/thor/parser/argument.rb
+++ b/lib/thor/parser/argument.rb
@@ -2,7 +2,7 @@ class Thor
   class Argument #:nodoc:
     VALID_TYPES = [:numeric, :hash, :array, :string]
 
-    attr_reader :name, :description, :enum, :required, :type, :default, :banner
+    attr_reader :name, :description, :enum, :required, :type, :default, :banner, :validator, :validator_description
     alias_method :human_name, :name
 
     def initialize(name, options = {})
@@ -13,13 +13,15 @@ class Thor
       fail ArgumentError, "#{class_name} name can't be nil."                         if name.nil?
       fail ArgumentError, "Type :#{type} is not valid for #{class_name.downcase}s."  if type && !valid_type?(type)
 
-      @name        = name.to_s
-      @description = options[:desc]
-      @required    = options.key?(:required) ? options[:required] : true
-      @type        = (type || :string).to_sym
-      @default     = options[:default]
-      @banner      = options[:banner] || default_banner
-      @enum        = options[:enum]
+      @name                  = name.to_s
+      @description           = options[:desc]
+      @required              = options.key?(:required) ? options[:required] : true
+      @type                  = (type || :string).to_sym
+      @default               = options[:default]
+      @banner                = options[:banner] || default_banner
+      @enum                  = options[:enum]
+      @validator             = options[:validator]
+      @validator_description = options[:validator_desc]
 
       validate! # Trigger specific validations
     end
@@ -49,6 +51,26 @@ class Thor
       elsif @enum && !@enum.is_a?(Array)
         fail ArgumentError, "An argument cannot have an enum other than an array."
       end
+
+      validate_validator!
+    end
+
+    def validate_validator!
+      fail ArgumentError, "A validator needs to respond to #call" if validator_with_invalid_api?
+      fail ArgumentError, "A validator needs a description. Please define :validator_desc" if validator_without_description?
+      fail ArgumentError, "It does not make sense to use both :validator and :enum. Please use either :validator or :enum" if use_enum_and_validator_together?
+    end
+
+    def use_enum_and_validator_together?
+      validator && enum
+    end
+
+    def validator_with_invalid_api?
+      validator && !validator.respond_to?(:call)
+    end
+
+    def validator_without_description?
+      validator && !validator_description
     end
 
     def valid_type?(type)

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -84,6 +84,12 @@ class Thor
       peek && peek.to_s !~ /^-/
     end
 
+    def for_switch(name)
+      if @switches.is_a?(Hash) && switch = @switches[name]
+        yield(switch)
+      end
+    end
+
     # Runs through the argument array getting strings that contains ":" and
     # mark it as a hash:
     #
@@ -100,7 +106,7 @@ class Thor
       while current_is_value? && peek.include?(":")
         key, value = shift.split(":", 2)
 
-        if @switches.is_a?(Hash) && switch = @switches[name]
+        for_switch name do |switch|
           if switch.validator && !switch.validator.call(key, value)
             fail MalformattedArgumentError, "Expected '#{name}=#{key}:#{value}' to return true for `:validator`, but it returns false"
           end
@@ -127,7 +133,7 @@ class Thor
       while current_is_value?
         value = shift
 
-        if @switches.is_a?(Hash) && switch = @switches[name]
+        for_switch name do |switch|
           if switch.validator && !switch.validator.call(value)
             fail MalformattedArgumentError, "Expected '#{name}=[#{value}, ...]' to return true for `:validator`, but it returns false"
           end
@@ -151,7 +157,7 @@ class Thor
 
       value = $&.index(".") ? shift.to_f : shift.to_i
 
-      if @switches.is_a?(Hash) && switch = @switches[name]
+      for_switch name do |switch|
         if switch.validator && !switch.validator.call(value)
           fail MalformattedArgumentError, "Expected '#{name}=#{value}' to return true for `:validator`, but it returns false"
         elsif switch.enum && !switch.enum.include?(value)
@@ -172,7 +178,7 @@ class Thor
         nil
       else
         value = shift
-        if @switches.is_a?(Hash) && switch = @switches[name] # rubocop:disable AssignmentInCondition
+        for_switch name do |switch|
           if switch.validator && !switch.validator.call(value)
             fail MalformattedArgumentError, "Expected '#{name}=#{value}' to return true for `:validator`, but it returns false"
           elsif switch.enum && !switch.enum.include?(value)

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -99,6 +99,13 @@ class Thor
 
       while current_is_value? && peek.include?(":")
         key, value = shift.split(":", 2)
+
+        if @switches.is_a?(Hash) && switch = @switches[name]
+          if switch.validator && !switch.validator.call(key, value)
+            fail MalformattedArgumentError, "Expected '#{name}=#{key}:#{value}' to return true for `:validator`, but it returns false"
+          end
+        end
+
         fail MalformattedArgumentError, "You can't specify '#{key}' more than once in option '#{name}'; got #{key}:#{hash[key]} and #{key}:#{value}" if hash.include? key
         hash[key] = value
       end
@@ -117,7 +124,17 @@ class Thor
     def parse_array(name)
       return shift if peek.is_a?(Array)
       array = []
-      array << shift while current_is_value?
+      while current_is_value?
+        value = shift
+
+        if @switches.is_a?(Hash) && switch = @switches[name]
+          if switch.validator && !switch.validator.call(value)
+            fail MalformattedArgumentError, "Expected '#{name}=[#{value}, ...]' to return true for `:validator`, but it returns false"
+          end
+        end
+
+        array << value
+      end
       array
     end
 
@@ -133,11 +150,15 @@ class Thor
       end
 
       value = $&.index(".") ? shift.to_f : shift.to_i
+
       if @switches.is_a?(Hash) && switch = @switches[name]
-        if switch.enum && !switch.enum.include?(value)
+        if switch.validator && !switch.validator.call(value)
+          fail MalformattedArgumentError, "Expected '#{name}=#{value}' to return true for `:validator`, but it returns false"
+        elsif switch.enum && !switch.enum.include?(value)
           fail MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
         end
       end
+
       value
     end
 
@@ -152,7 +173,9 @@ class Thor
       else
         value = shift
         if @switches.is_a?(Hash) && switch = @switches[name] # rubocop:disable AssignmentInCondition
-          if switch.enum && !switch.enum.include?(value)
+          if switch.validator && !switch.validator.call(value)
+            fail MalformattedArgumentError, "Expected '#{name}=#{value}' to return true for `:validator`, but it returns false"
+          elsif switch.enum && !switch.enum.include?(value)
             fail MalformattedArgumentError, "Expected '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
           end
         end

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -109,6 +109,13 @@ class Thor
     def validate!
       fail ArgumentError, "An option cannot be boolean and required." if boolean? && required?
       validate_default_type!
+      validate_validator!
+    end
+
+    def validate_validator!
+      fail ArgumentError, "A validator is only supported for type = :string, :numeric, :array or :hash" if type_cannot_have_validator?
+
+      super
     end
 
     def validate_default_type!
@@ -123,6 +130,10 @@ class Thor
                        @default.class.name.downcase.to_sym
                      end
       fail ArgumentError, "An option's default must match its type." unless default_type == @type
+    end
+
+    def type_cannot_have_validator?
+      validator && ![:string, :numeric, :array, :hash].include?(type)
     end
 
     def dasherized?

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -91,6 +91,12 @@ END
     [name, options, args]
   end
 
+  method_option :my_option, :type => :string, :validator => proc { |v| v == 'hello world' }, :validator_desc => 'Needs to be "hello world"'
+  desc 'with_validator', 'Check option with validator'
+  def with_validator
+    [options]
+  end
+
   class AnotherScript < Thor
     desc "baz", "do some bazing"
     def baz

--- a/spec/parser/argument_spec.rb
+++ b/spec/parser/argument_spec.rb
@@ -31,6 +31,24 @@ describe Thor::Argument do
         argument(:command, :type => :string, :enum => "bar")
       end.to raise_error(ArgumentError, "An argument cannot have an enum other than an array.")
     end
+
+    it "raises an error if validator does not have call-method" do
+      expect do
+        argument(:command, :type => :string, :validator => Class.new.new, :validator_desc => 'Validator Description')
+      end.to raise_error(ArgumentError, "A validator needs to respond to #call")
+    end
+
+    it "raises an error if validator does not have a description" do
+      expect do
+        argument(:command, :type => :string, :validator => proc {})
+      end.to raise_error(ArgumentError, "A validator needs a description. Please define :validator_desc")
+    end
+
+    it "raises an error if validator and enum-option are used together" do
+      expect do
+        argument(:command, :type => :string, :validator => proc {}, :validator_desc => 'A validator description', :enum => ['a', 'b'])
+      end.to raise_error(ArgumentError, "It does not make sense to use both :validator and :enum. Please use either :validator or :enum")
+    end
   end
 
   describe "#usage" do

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -141,6 +141,30 @@ describe Thor::Option do
     end.to raise_error(ArgumentError, "An option's default must match its type.")
   end
 
+  it "raises an error if validator is used with boolean option" do
+    expect do
+      option = option("foo", :type => :boolean, :validator => proc {}, :validator_desc => 'Validator Description')
+    end.to raise_error(ArgumentError, "A validator is only supported for type = :string, :numeric, :array or :hash")
+  end
+
+  it "raises an error if validator does not have call-method" do
+    expect do
+      option = option("foo", :type => :string, :validator => Class.new.new, :validator_desc => 'Validator Description')
+    end.to raise_error(ArgumentError, "A validator needs to respond to #call")
+  end
+
+  it "raises an error if validator does not have a description" do
+    expect do
+      option = option("foo", :type => :string, :validator => proc {})
+    end.to raise_error(ArgumentError, "A validator needs a description. Please define :validator_desc")
+  end
+
+  it "raises an error if validator and enum-option are used together" do
+    expect do
+      option = option(:foo, :type => :string, :validator => proc {}, :validator_desc => 'A validator description', :enum => ['a', 'b'])
+    end.to raise_error(ArgumentError, "It does not make sense to use both :validator and :enum. Please use either :validator or :enum")
+  end
+
   it "boolean options cannot be required" do
     expect do
       option("foo", :required => true, :type => :boolean)

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -295,6 +295,18 @@ describe Thor::Options do
         expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError,
             "Expected '--fruit' to be one of #{enum.join(', ')}; got orange")
       end
+
+      it "accepts value when value 't match validator" do
+        create :fruit => Thor::Option.new("fruit", :type => :string, :validator => proc { |v| /orange/ === v }, :validator_desc => 'description')
+        expect { parse("--fruit", "orange") }.not_to raise_error
+      end
+
+      it "raises error when value doesn't match validator" do
+        create :fruit => Thor::Option.new("fruit", :type => :string, :validator => proc { |v| /banana/ === v }, :validator_desc => 'description')
+        expect { parse("--fruit", "orange") }.to raise_error(Thor::MalformattedArgumentError, 
+                                                             "Expected '--fruit=orange' to return true for `:validator`, but it returns false"
+                                                            )
+      end
     end
 
     describe "with :boolean type" do
@@ -368,6 +380,18 @@ describe Thor::Options do
       it "must not allow the same hash key to be specified multiple times" do
         expect {parse("--attributes", "name:string", "name:integer")}.to raise_error(Thor::MalformattedArgumentError, "You can't specify 'name' more than once in option '--attributes'; got name:string and name:integer")
       end
+
+      it "accepts value when value 't match validator" do
+        create :attributes => Thor::Option.new("attributes", :type => :hash, :validator => proc { |k,v| /name/ === k && /string/ === v}, :validator_desc => 'description')
+        expect { parse("--attributes", "name:string") }.not_to raise_error
+      end
+
+      it "raises error when value doesn't match validator" do
+        create :attributes => Thor::Option.new("attributes", :type => :hash, :validator => proc { |k,v| /name/ === k && /longstring/ === v}, :validator_desc => 'description')
+        expect { parse("--attributes", "name:string") }.to raise_error(Thor::MalformattedArgumentError, 
+                                                             "Expected '--attributes=name:string' to return true for `:validator`, but it returns false"
+                                                            )
+      end
     end
 
     describe "with :array type" do
@@ -385,6 +409,18 @@ describe Thor::Options do
 
       it "must not mix values with other switches" do
         expect(parse("--attributes", "a", "b", "c", "--baz", "cool")["attributes"]).to eq(%w[a b c])
+      end
+
+      it "accepts value when value 't match validator" do
+        create :attributes => Thor::Option.new("attributes", :type => :array, :validator => proc { |v| v.to_i < 4 }, :validator_desc => 'description')
+        expect { parse("--attributes", "1", "2", "3") }.not_to raise_error
+      end
+
+      it "raises error when value doesn't match validator" do
+        create :attributes => Thor::Option.new("attributes", :type => :array, :validator => proc { |v| v.to_i > 3 }, :validator_desc => 'description')
+        expect { parse("--attributes", "1", "4") }.to raise_error(Thor::MalformattedArgumentError, 
+                                                             "Expected '--attributes=[1, ...]' to return true for `:validator`, but it returns false"
+                                                            )
       end
     end
 
@@ -412,7 +448,18 @@ describe Thor::Options do
         expect { parse("--limit", "3") }.to raise_error(Thor::MalformattedArgumentError,
                                                         "Expected '--limit' to be one of #{enum.join(', ')}; got 3")
       end
-    end
 
+      it "accepts value when value 't match validator" do
+        create :limit => Thor::Option.new("limit", :type => :numeric, :validator => proc { |v| v == 3 }, :validator_desc => 'description')
+        expect { parse("--limit", "3") }.not_to raise_error
+      end
+
+      it "raises error when value doesn't match validator" do
+        create :limit => Thor::Option.new("limit", :type => :numeric, :validator => proc { |v| v < 3 }, :validator_desc => 'description')
+        expect { parse("--limit", "3") }.to raise_error(Thor::MalformattedArgumentError, 
+                                                             "Expected '--limit=3' to return true for `:validator`, but it returns false"
+                                                            )
+      end
+    end
   end
 end

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -384,6 +384,10 @@ do some fooing
 END
       end
 
+      it "outputs information about validations as well" do
+        expect(capture(:stdout) { MyScript.command_help(shell, "with_validator") }).to include 'Validation'
+      end
+
       it "raises an error if the command can't be found" do
         expect do
           MyScript.command_help(shell, "unknown")


### PR DESCRIPTION
### Is

You can control what values of arguments/options `thor` accepts via `:string`, `:boolean` (options only), `:numeric`, `:array` and `:hash`. Sometimes that's not enough. 

Given you've got an application like [`middleman`](https://github.com/middleman/middleman) I used regularly - a static site generator similar to `jekyll` - which has a `server`-command. This command has at least two options "relevant" for this use case:
- `host`
- `port`

A host name is defined in [RFC 952](http://tools.ietf.org/html/rfc952) and is not allowed to include blanks or space characters -- look for "No blank or space characters are permitted as part of a name". It needs to match `^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$` to be valid. Using just `:string` is not enough to validate a host name.

A TCP port is defined as an integer from 0 to 65536 - see more in [RFC6056](https://tools.ietf.org/html/rfc6056#page-5). It needs to match `(0..65535).include?(port)`. Just checking if it's a number is not enough either.

Today those checks are not possible, unfortunately.
### Should

It should be possible to define a more granular check for `:string`, `:numeric`, `:array` and `:hash`. It should iterate over all values of an `:array`\- and over all keys/values of a `:hash`-option/argument. The validator should have an easy to use API, e.g. `validator#call` -- if `#call` is used, you can use a proc/lambda-object as validator. To make it clear to users, that there are some more checks a validator must also have a description for those checks. Because a proc/lambda should be supported as well, this should be another option for `#method_option`.

Using the examples from above the validator, a validator should look like this:

**Port Example**

``` ruby
option :port, type: :numeric, validator: proc { |port| (0..65535).include?(port) }, validator_desc: 'Needs be in range 0-65535'
```

**Hostname Example**

``` ruby
option :hostname, type: :string, validator: proc { |name| /^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/ === name }, validator_desc: 'Needs be valid hostname, see RFC 952 for more on this topic'
```

This PR implements this.
### To be discussed
- Is it ok for you , that I add `:validator` + `:validator_desc`?
- Naming of new options, `:validator` and `:validator_desc`
  I used `_desc` because there's an option named `:desc` for a option-description already
- If a validator is given, having `:validator_desc` will be enforced, otherwise the developer may forget to add a clear description for end users, that a validator is in use and what the requirements of this validator are
- Add hint to help for `validation`. I thought that it might be helpful to make the user aware of a validation by adding the relevant information to the help command
- Is the interface of a validator ok for you, require it to have a `#call`-method? I thought that this is the most flexible and easy to use solution
- I added the information about the new options to the `source_code`-documentation. Is there any other place - besides the wiki - where I need to document the new options? I will update the wiki, if this PR is accepted.
### Checklist From CONTRIBUTING
- [ ] It hasn’t been reviewed.
- [x] It includes specs for new functionality.
- [x] It includes documentation for new functionality.
- [x] It changes relevant documentation, comments, or specs.
- [x] It does not changes behavior of an existing public API, breaking backward compatibility. It only extends it
- [x] It does not break the tests on a supported platform - ~~waiting for CI to be finished~~.
- [x] It merges cleanly (as of the time submitting).
