### PR TITLE
Allow values to include hyphens when specified unambiguously with "="

### DIFF
--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -257,6 +257,7 @@ describe Thor::Options do
         expect(parse("-f=12")["foo"]).to eq("12")
         expect(parse("--foo=12")["foo"]).to eq("12")
         expect(parse("--foo=bar=baz")["foo"]).to eq("bar=baz")
+        expect(parse("--foo=-bar")["foo"]).to eq("-bar")
       end
 
       it "must accept underscores switch=value assignment" do


### PR DESCRIPTION
:rainbow: 

I noticed that if an option value begins with a "-" (`/^-/`), it will be parsed as a switch, even in cases like

```
--foo=-bar
```

where it seems that the presence of the "=" allows the value (`-bar`) to be unambiguously parsed as a value instead of a switch.

The new spec expectation should be clear; I'm less confident in the implementation, as the current implementation relies quite a bit on several stateful instance variables.
