### PR TITLE
Support subcommands with hyphens

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -353,7 +353,7 @@ class Thor
     # The method responsible for dispatching given the args.
     def dispatch(meth, given_args, given_opts, config) #:nodoc: # rubocop:disable MethodLength
       meth ||= retrieve_command_name(given_args)
-      command = all_commands[normalize_command_name(meth)]
+      command = all_commands[meth] || all_commands[normalize_command_name(meth)]
 
       if !command && config[:invoked_via_subcommand]
         # We're a subcommand and our first argument didn't match any of our


### PR DESCRIPTION
Adding support for subcommands with hyphens because I ran into this problem and found someone else had it too and they didn't find an answer: https://stackoverflow.com/questions/40064574/hyphenated-subcommand-in-thor

Problem: You can't use hyphenated subcommands:


```
require 'thor'

class HasHyphens < Thor
  desc 'puts-hi', 'prints hi'
  def puts_hi
    puts 'hi'
  end
end

class Main < Thor
  desc 'has-hyphens', 'this class has hyphens'
  subcommand 'has-hyphens', HasHyphens
end

Main.start(ARGV)
```

Running it with current:

```
john@validum:~/work/thor$ ruby /tmp/demo.rb has-hyphens puts-hi
Could not find command "has-hyphens".
```

Testing the diff (there's no spec for dispatch)

```
john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb 
Commands:
  demo.rb has-hyphens     # this class has hyphens
  demo.rb help [COMMAND]  # Describe available commands or one specific command

john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb help
Commands:
  demo.rb has-hyphens     # this class has hyphens
  demo.rb help [COMMAND]  # Describe available commands or one specific command

john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb has-hyphens
Commands:
  demo.rb has-hyphens help [COMMAND]  # Describe subcommands or one specific subcommand
  demo.rb has-hyphens puts-hi         # prints hi

john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb has-hyphens help
Commands:
  demo.rb has-hyphens help [COMMAND]  # Describe subcommands or one specific subcommand
  demo.rb has-hyphens puts-hi         # prints hi

john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb has-hyphens help puts-hi
Usage:
  demo.rb has-hyphens puts-hi

prints hi
john@validum:~/work/thor$ ruby -Ilib /tmp/demo.rb has-hyphens puts-hi
hi
john@validum:~/work/thor$ 
```

As an aside, debugging this revealed an interesting feature of Ruby. Methods can have hyphens too!

```
[1] pry(main)> class Foo
[1] pry(main)*   define_method('has-hyphens'.to_sym) { puts 'has hypens, it does' }
[1] pry(main)* end
=> :"has-hyphens"
[2] pry(main)> foo = Foo.new
=> #<Foo:0x000055ed87630518>
[3] pry(main)> foo.send(:'has-hyphens')
has hypens, it does
=> nil
[4] pry(main)>
```