### PR TITLE
utf8 identical checking

### DIFF
--- a/lib/thor/actions/create_file.rb
+++ b/lib/thor/actions/create_file.rb
@@ -43,7 +43,7 @@ class Thor
       # Boolean:: true if it is identical, false otherwise.
       #
       def identical?
-        exists? && File.binread(destination) == render
+        exists? && File.binread(destination) == String.new(render).force_encoding("ASCII-8BIT")
       end
 
       # Holds the content to be added to the file.

--- a/spec/actions/create_file_spec.rb
+++ b/spec/actions/create_file_spec.rb
@@ -11,7 +11,7 @@ describe Thor::Actions::CreateFile do
     @base = MyCounter.new([1, 2], options, :destination_root => destination_root)
     allow(@base).to receive(:file_name).and_return("rdoc")
 
-    @action = Thor::Actions::CreateFile.new(@base, destination, "CONFIGURATION", {:verbose => !@silence}.merge(config))
+    @action = Thor::Actions::CreateFile.new(@base, destination, "CONFIGURATION\n配置", {:verbose => !@silence}.merge(config))
   end
 
   def invoke!


### PR DESCRIPTION
File.binread returns string with ASCII-8BIT encoding. but the rendered result is Utf8 encoding. For non-ascii characters, although the content is same, the comparison will return false. when we invoke migration generate with force option. it will delete the old migration file, and create a new migration file with the same content.