### PR TITLE
Adds a top level package description

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -13,6 +13,16 @@ class Thor
       @package_name = name.nil? || name == "" ? nil : name
     end
 
+    # Allow users to add a description of the package
+    #
+    # === Parameters
+    # description<String>
+    # options<Hash>
+    #
+    def package_description(description, _ = {})
+      @package_description = description.nil? || description == "" ? nil : description
+    end
+
     # Sets the default command when thor is executed without an explicit command to be called.
     #
     # ==== Parameters
@@ -193,6 +203,11 @@ class Thor
         list += klass.printable_commands(false)
       end
       list.sort! { |a, b| a[0] <=> b[0] }
+
+      if defined?(@package_description) && @package_description
+        shell.say "#{@package_description}"
+        shell.say
+      end
 
       if defined?(@package_name) && @package_name
         shell.say "#{@package_name} commands:"

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -193,8 +193,8 @@ describe Thor::Base do
       thorfile = File.join(File.dirname(__FILE__), "fixtures", "script.thor")
       expect(Thor::Base.subclass_files[File.expand_path(thorfile)]).to eq([
         MyScript, MyScript::AnotherScript, MyChildScript, Barn,
-        PackageNameScript, Scripts::MyScript, Scripts::MyDefaults,
-        Scripts::ChildDefault, Scripts::Arities
+        PackageNameScript, PackageNameAndDescriptionScript, Scripts::MyScript,
+        Scripts::MyDefaults, Scripts::ChildDefault, Scripts::Arities
       ])
     end
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -166,6 +166,11 @@ class PackageNameScript < Thor
   package_name "Baboon"
 end
 
+class PackageNameAndDescriptionScript < Thor
+  package_name "marvel"
+  package_description "A command-line interpreter for the Marvel Corporation."
+end
+
 module Scripts
   class MyScript < MyChildScript
     argument :accessor, :type => :string

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -354,6 +354,14 @@ describe Thor do
       content = capture(:stdout) { MyScript.start(%w(help)) }
       expect(content).to match(/Commands:/m)
     end
+
+    describe "#package_description" do
+      it "provides a description for a command when the package_description is assigned" do
+        content = capture(:stdout) { PackageNameAndDescriptionScript.start(%w(help)) }
+        expect(content).to match(/A command-line interpreter for the Marvel Corporation./m)
+        expect(content).to match(/marvel commands:/m)
+      end
+    end
   end
 
   describe "#desc" do


### PR DESCRIPTION
There could be cases where users have a very short name for the package
name, which is the cli name, in such cases it would be good to provide a
way to add a top-level package description just like there is for
sub-commands.

## Example.

With the following class:
```
class Marvel < Thor
  package_name "marvel"
  package_description "A command-line interpreter for the Marvel Corporation."
end
```

We would see the follosing help:
```
$ marvel help
A command-line interpreter for the Marvel Corporation.

marvel commands:
```

Signed-off-by: Salim Afiune <afiune@chef.io>