### PR TITLE
Allow leading hyphen in switch values when specified with =

### DIFF
--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -45,7 +45,7 @@ class Thor
       @switches = {}
       @extra = []
       @stopped_parsing_after_extra_index = nil
-      @force_current_to_be_value = false
+      @is_switch_value = false
 
       options.each do |option|
         @switches[option.switch_name] = option
@@ -76,18 +76,18 @@ class Thor
     end
 
     def shift
-      @force_current_to_be_value = false
+      @is_switch_value = false
       super
     end
 
     def unshift(arg, force_value: false)
-      @force_current_to_be_value = force_value
+      @is_switch_value = force_value
       super(arg)
     end
 
     def parse(args) # rubocop:disable MethodLength
       @pile = args.dup
-      @force_current_to_be_value = false
+      @is_switch_value = false
       @parsing_options = true
 
       while peek
@@ -163,7 +163,7 @@ class Thor
     # Two booleans are returned.  The first is true if the current value
     # starts with a hyphen; the second is true if it is a registered switch.
     def current_is_switch?
-      return [false, false] if @force_current_to_be_value
+      return [false, false] if @is_switch_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM
         [true, switch?($1)]
@@ -175,7 +175,7 @@ class Thor
     end
 
     def current_is_switch_formatted?
-      return false if @force_current_to_be_value
+      return false if @is_switch_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM, SHORT_SQ_RE
         true
@@ -185,7 +185,7 @@ class Thor
     end
 
     def current_is_value?
-      return true if @force_current_to_be_value
+      return true if @is_switch_value
       peek && (!parsing_options? || super)
     end
 

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -45,7 +45,7 @@ class Thor
       @switches = {}
       @extra = []
       @stopped_parsing_after_extra_index = nil
-      @is_switch_value = false
+      @is_treated_as_value = false
 
       options.each do |option|
         @switches[option.switch_name] = option
@@ -76,18 +76,18 @@ class Thor
     end
 
     def shift
-      @is_switch_value = false
+      @is_treated_as_value = false
       super
     end
 
-    def unshift(arg, force_value: false)
-      @is_switch_value = force_value
+    def unshift(arg, is_value: false)
+      @is_treated_as_value = is_value
       super(arg)
     end
 
     def parse(args) # rubocop:disable MethodLength
       @pile = args.dup
-      @is_switch_value = false
+      @is_treated_as_value = false
       @parsing_options = true
 
       while peek
@@ -101,7 +101,7 @@ class Thor
               unshift($1.split("").map { |f| "-#{f}" })
               next
             when EQ_RE
-              unshift($2, force_value: true)
+              unshift($2, is_value: true)
               switch = $1
             when SHORT_NUM
               unshift($2)
@@ -163,7 +163,7 @@ class Thor
     # Two booleans are returned.  The first is true if the current value
     # starts with a hyphen; the second is true if it is a registered switch.
     def current_is_switch?
-      return [false, false] if @is_switch_value
+      return [false, false] if @is_treated_as_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM
         [true, switch?($1)]
@@ -175,7 +175,7 @@ class Thor
     end
 
     def current_is_switch_formatted?
-      return false if @is_switch_value
+      return false if @is_treated_as_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM, SHORT_SQ_RE
         true
@@ -185,7 +185,7 @@ class Thor
     end
 
     def current_is_value?
-      return true if @is_switch_value
+      return true if @is_treated_as_value
       peek && (!parsing_options? || super)
     end
 

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -45,6 +45,7 @@ class Thor
       @switches = {}
       @extra = []
       @stopped_parsing_after_extra_index = nil
+      @force_current_to_be_value = false
 
       options.each do |option|
         @switches[option.switch_name] = option
@@ -74,8 +75,19 @@ class Thor
       end
     end
 
+    def shift
+      @force_current_to_be_value = false
+      super
+    end
+
+    def unshift(arg, force_value: false)
+      @force_current_to_be_value = force_value
+      super(arg)
+    end
+
     def parse(args) # rubocop:disable MethodLength
       @pile = args.dup
+      @force_current_to_be_value = false
       @parsing_options = true
 
       while peek
@@ -88,7 +100,10 @@ class Thor
             when SHORT_SQ_RE
               unshift($1.split("").map { |f| "-#{f}" })
               next
-            when EQ_RE, SHORT_NUM
+            when EQ_RE
+              unshift($2, force_value: true)
+              switch = $1
+            when SHORT_NUM
               unshift($2)
               switch = $1
             when LONG_RE, SHORT_RE
@@ -148,6 +163,7 @@ class Thor
     # Two booleans are returned.  The first is true if the current value
     # starts with a hyphen; the second is true if it is a registered switch.
     def current_is_switch?
+      return [false, false] if @force_current_to_be_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM
         [true, switch?($1)]
@@ -159,6 +175,7 @@ class Thor
     end
 
     def current_is_switch_formatted?
+      return false if @force_current_to_be_value
       case peek
       when LONG_RE, SHORT_RE, EQ_RE, SHORT_NUM, SHORT_SQ_RE
         true
@@ -168,6 +185,7 @@ class Thor
     end
 
     def current_is_value?
+      return true if @force_current_to_be_value
       peek && (!parsing_options? || super)
     end
 

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -263,6 +263,8 @@ describe Thor::Options do
         expect(parse("-f=12")["foo"]).to eq("12")
         expect(parse("--foo=12")["foo"]).to eq("12")
         expect(parse("--foo=bar=baz")["foo"]).to eq("bar=baz")
+        expect(parse("--foo=-bar")["foo"]).to eq("-bar")
+        expect(parse("--foo=-bar -baz")["foo"]).to eq("-bar -baz")
       end
 
       it "must accept underscores switch=value assignment" do
@@ -398,6 +400,7 @@ describe Thor::Options do
 
       it "accepts a switch=<value> assignment" do
         expect(parse("--attributes=name:string", "age:integer")["attributes"]).to eq("name" => "string", "age" => "integer")
+        expect(parse("--attributes=-name:string", "age:integer", "--gender:string")["attributes"]).to eq("-name" => "string", "age" => "integer")
       end
 
       it "accepts a switch <value> assignment" do
@@ -425,6 +428,7 @@ describe Thor::Options do
 
       it "accepts a switch=<value> assignment" do
         expect(parse("--attributes=a", "b", "c")["attributes"]).to eq(%w(a b c))
+        expect(parse("--attributes=-a", "b", "-c")["attributes"]).to eq(%w(-a b))
       end
 
       it "accepts a switch <value> assignment" do


### PR DESCRIPTION
This is a fixed version of #498.

This allows `--foo=-bar` to work.

The implementation works by keeping track of an additional piece of state `@force_current_to_be_value`, which is maintained inside `shift` and `unshift` to ensure it matches the state in `@pile`.