### PR TITLE
🌧️ long_desc: new option to disable wrapping

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -81,7 +81,7 @@ class Thor
         command.long_description = long_description if long_description
       else
         @long_desc = long_description
-        @long_desc_wrap = options[:wrap] || options[:wrap].nil?
+        @long_desc_wrap = options[:wrap] != false
       end
     end
 

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -65,8 +65,15 @@ class Thor
 
     # Defines the long description of the next command.
     #
+    # Long description is by default indented, line-wrapped and repeated whitespace merged.
+    # In order to print long description verbatim, with indentation and spacing exactly
+    # as found in the code, use the +wrap+ option
+    #
+    #   long_desc 'your very long description', wrap: false
+    #
     # ==== Parameters
     # long description<String>
+    # options<Hash>
     #
     def long_desc(long_description, options = {})
       if options[:for]
@@ -74,6 +81,7 @@ class Thor
         command.long_description = long_description if long_description
       else
         @long_desc = long_description
+        @long_desc_wrap = options[:wrap] || options[:wrap].nil?
       end
     end
 
@@ -258,7 +266,11 @@ class Thor
 
       if command.long_description
         shell.say "Description:"
-        shell.print_wrapped(command.long_description, indent: 2)
+        if command.wrap_long_description
+          shell.print_wrapped(command.long_description, indent: 2)
+        else
+          shell.say command.long_description
+        end
       else
         shell.say command.description
       end
@@ -535,14 +547,15 @@ class Thor
       @usage ||= nil
       @desc ||= nil
       @long_desc ||= nil
+      @long_desc_wrap ||= nil
       @hide ||= nil
 
       if @usage && @desc
         base_class = @hide ? Thor::HiddenCommand : Thor::Command
         relations = {exclusive_option_names: method_exclusive_option_names,
           at_least_one_option_names: method_at_least_one_option_names}
-        commands[meth] = base_class.new(meth, @desc, @long_desc, @usage, method_options, relations)
-        @usage, @desc, @long_desc, @method_options, @hide = nil
+        commands[meth] = base_class.new(meth, @desc, @long_desc, @long_desc_wrap, @usage, method_options, relations)
+        @usage, @desc, @long_desc, @long_desc_wrap, @method_options, @hide = nil
         @method_exclusive_option_names, @method_at_least_one_option_names = nil
         true
       elsif all_commands[meth] || meth == "method_missing"

--- a/lib/thor/command.rb
+++ b/lib/thor/command.rb
@@ -1,9 +1,9 @@
 class Thor
-  class Command < Struct.new(:name, :description, :long_description, :usage, :options, :options_relation, :ancestor_name)
+  class Command < Struct.new(:name, :description, :long_description, :wrap_long_description, :usage, :options, :options_relation, :ancestor_name)
     FILE_REGEXP = /^#{Regexp.escape(File.dirname(__FILE__))}/
 
-    def initialize(name, description, long_description, usage, options = nil, options_relation = nil)
-      super(name.to_s, description, long_description, usage, options || {}, options_relation || {})
+    def initialize(name, description, long_description, wrap_long_description, usage, options = nil, options_relation = nil)
+      super(name.to_s, description, long_description, wrap_long_description, usage, options || {}, options_relation || {})
     end
 
     def initialize_copy(other) #:nodoc:
@@ -136,7 +136,7 @@ class Thor
   # A dynamic command that handles method missing scenarios.
   class DynamicCommand < Command
     def initialize(name, options = nil)
-      super(name.to_s, "A dynamically-generated command", name.to_s, name.to_s, options)
+      super(name.to_s, "A dynamically-generated command", name.to_s, nil, name.to_s, options)
     end
 
     def run(instance, args = [])

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -6,7 +6,7 @@ describe Thor::Command do
       options[key] = Thor::Option.parse(key, value)
     end
 
-    @command ||= Thor::Command.new(:can_has, "I can has cheezburger", "I can has cheezburger\nLots and lots of it", usage, options)
+    @command ||= Thor::Command.new(:can_has, "I can has cheezburger", "I can has cheezburger\nLots and lots of it", nil, usage, options)
   end
 
   describe "#formatted_usage" do
@@ -54,7 +54,7 @@ describe Thor::Command do
 
   describe "#dup" do
     it "dup options hash" do
-      command = Thor::Command.new("can_has", nil, nil, nil, foo: true, bar: :required)
+      command = Thor::Command.new("can_has", nil, nil, nil, nil, foo: true, bar: :required)
       command.dup.options.delete(:foo)
       expect(command.options[:foo]).to be
     end

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -96,6 +96,18 @@ END
   def name_with_dashes
   end
 
+  desc "long_description", "a" * 80
+  long_desc <<-D, wrap: false
+No added indentation,   Inline
+whatespace not merged,
+Linebreaks preserved
+  and
+    indentation
+  too
+  D
+  def long_description_unwrapped
+  end
+
   method_options :all => :boolean
   method_option :lazy, :lazy_default => "yes"
   method_option :lazy_numeric, :type => :numeric, :lazy_default => 42

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -642,6 +642,21 @@ Description:
 HELP
       end
 
+      it "prints long description unwrapped if asked for" do
+        expect(capture(:stdout) { MyScript.command_help(shell, "long_description_unwrapped") }).to eq(<<-HELP)
+Usage:
+  thor my_script:long_description
+
+Description:
+No added indentation,   Inline
+whatespace not merged,
+Linebreaks preserved
+  and
+    indentation
+  too
+HELP
+      end
+
       it "doesn't assign the long description to the next command without one" do
         expect(capture(:stdout) do
           MyScript.command_help(shell, "name_with_dashes")


### PR DESCRIPTION
# What it does

The PR implements [this suggestion](https://github.com/erikhuda/thor/issues/398#issuecomment-364503506) from the #398 comments. `long_desc` now receives a new option `wrap`. Setting it to `false` disables wrapping of the long description and prints it verbatim.

```ruby
long_desc <<~MSG, wrap: false
  formatted text that is not wrapped
 ...
MSG
```

# What it breaks

It adds a new obligatory constructor argument to `Thor::Command`. If the constructor is considered part of the public API, this may be a problem.

*(I did read CONTRIBUTING.md, but I prefer not to use the rainbow emoji because of the meanings it usually carries nowadays, hence the cloud in PR title.)*