### PR TITLE
use the correct class for shared namespaces

### DIFF
--- a/lib/thor/util.rb
+++ b/lib/thor/util.rb
@@ -21,9 +21,9 @@ class Thor
       # ==== Parameters
       # namespace<String>:: The namespace to search for.
       #
-      def find_by_namespace(namespace, command = nil)
+      def find_by_namespace(namespace)
         namespace = "default#{namespace}" if namespace.empty? || namespace =~ /^:/
-        Thor::Base.subclasses.detect { |klass| klass.namespace == namespace and command.nil? || klass.commands.keys.include?(command) }
+        Thor::Base.subclasses.detect { |klass| klass.namespace == namespace }
       end
 
       # Receives a constant and converts it to a Thor namespace. Since Thor
@@ -130,10 +130,10 @@ class Thor
       #
       def find_class_and_command_by_namespace(namespace, fallback = true)
         if namespace.include?(":") # look for a namespaced command
-          pieces  = namespace.split(":")
-          command = pieces.pop
-          klass   = Thor::Util.find_by_namespace(pieces.join(":"), command)
-          klass ||= Thor::Util.find_by_namespace(pieces.join(":"))
+          *pieces, command  = namespace.split(":")
+          namespace = pieces.join(":")
+          namespace = "default" if namespace.empty?
+          klass = Thor::Base.subclasses.detect { |klass| klass.namespace == namespace && klass.commands.keys.include?(command) }
         end
         unless klass # look for a Thor::Group with the right name
           klass = Thor::Util.find_by_namespace(namespace)

--- a/lib/thor/util.rb
+++ b/lib/thor/util.rb
@@ -21,9 +21,9 @@ class Thor
       # ==== Parameters
       # namespace<String>:: The namespace to search for.
       #
-      def find_by_namespace(namespace)
+      def find_by_namespace(namespace, command = nil)
         namespace = "default#{namespace}" if namespace.empty? || namespace =~ /^:/
-        Thor::Base.subclasses.detect { |klass| klass.namespace == namespace }
+        Thor::Base.subclasses.detect { |klass| klass.namespace == namespace and command.nil? || klass.commands.keys.include?(command) }
       end
 
       # Receives a constant and converts it to a Thor namespace. Since Thor
@@ -132,7 +132,8 @@ class Thor
         if namespace.include?(":") # look for a namespaced command
           pieces  = namespace.split(":")
           command = pieces.pop
-          klass   = Thor::Util.find_by_namespace(pieces.join(":"))
+          klass   = Thor::Util.find_by_namespace(pieces.join(":"), command)
+          klass ||= Thor::Util.find_by_namespace(pieces.join(":"))
         end
         unless klass # look for a Thor::Group with the right name
           klass = Thor::Util.find_by_namespace(namespace)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -195,7 +195,7 @@ describe Thor::Base do
       expect(Thor::Base.subclass_files[File.expand_path(thorfile)]).to eq([
         MyScript, MyScript::AnotherScript, MyChildScript, Barn,
         PackageNameScript, Scripts::MyScript, Scripts::MyDefaults,
-        Scripts::ChildDefault, Scripts::Arities
+        Scripts::ChildDefault, Scripts::Arities, Apple, Pear
       ])
     end
 

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -251,10 +251,10 @@ end
 
 class Apple < Thor
   namespace :fruits
- desc 'apple', 'apple'; def apple; end
+  desc 'apple', 'apple'; def apple; end
 end
 
 class Pear < Thor
   namespace :fruits
- desc 'pear', 'pear'; def pear; end
+  desc 'pear', 'pear'; def pear; end
 end

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -249,3 +249,12 @@ module Scripts
   end
 end
 
+class Apple < Thor
+  namespace :fruits
+ desc 'apple', 'apple'; def apple; end
+end
+
+class Pear < Thor
+  namespace :fruits
+ desc 'pear', 'pear'; def pear; end
+end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -109,6 +109,11 @@ describe Thor::Util do
     it "falls back on the default namespace class if nothing else matches" do
       expect(Thor::Util.find_class_and_command_by_namespace("test")).to eq([Scripts::MyDefaults, "test"])
     end
+
+    it "returns correct Thor class and the command name when shared namespaces" do
+      expect(Thor::Util.find_class_and_command_by_namespace("fruits:apple")).to eq([Apple, "apple"])
+      expect(Thor::Util.find_class_and_command_by_namespace("fruits:pear")).to eq([Pear, "pear"])
+    end
   end
 
   describe "#thor_classes_in" do


### PR DESCRIPTION
check commands to find the correct class when multiple classes have the same namespace

this is related to https://github.com/rails/thor/issues/246 and https://github.com/rails/thor/pull/247

I'm assuming the intention was to allow multiple classes to use the same namespace. I guess I don't understand the reasoning for the namespace if it can only be used for a single class.

🌈