### PR TITLE
Fix for [Doubly nested subcommand creates wrong help output]

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -399,7 +399,7 @@ class Thor
     #
     def banner(command, namespace = nil, subcommand = false)
       command.formatted_usage(self, $thor_runner, subcommand).split("\n").map do |formatted_usage|
-        "#{basename} #{formatted_usage}"
+        "#{formatted_usage}"
       end.join("\n")
     end
 


### PR DESCRIPTION
Related this issue https://github.com/rails/thor/issues/627.
If we don't put command name (basename) there, it makes sense as arguments after the command.
Since it seems to take time to get subcommand names there, I think it's the solution for now.