### PR TITLE
Replace erikhuda/thor with rails/thor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage and documentation
 -----------------------
 Please see the [wiki][] for basic usage and other documentation on using Thor. You can also checkout the [official homepage][homepage].
 
-[wiki]: https://github.com/erikhuda/thor/wiki
+[wiki]: https://github.com/rails/thor/wiki
 [homepage]: http://whatisthor.com/
 
 Contributing

--- a/thor.gemspec
+++ b/thor.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |spec|
   spec.licenses = %w(MIT)
   spec.name = "thor"
   spec.metadata = {
-    "bug_tracker_uri" => "https://github.com/erikhuda/thor/issues",
-    "changelog_uri" => "https://github.com/erikhuda/thor/blob/master/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/rails/thor/issues",
+    "changelog_uri" => "https://github.com/rails/thor/blob/master/CHANGELOG.md",
     "documentation_uri" => "http://whatisthor.com/",
-    "source_code_uri" => "https://github.com/erikhuda/thor/tree/v#{Thor::VERSION}",
-    "wiki_uri" => "https://github.com/erikhuda/thor/wiki"
+    "source_code_uri" => "https://github.com/rails/thor/tree/v#{Thor::VERSION}",
+    "wiki_uri" => "https://github.com/rails/thor/wiki"
   }
   spec.require_paths = %w(lib)
   spec.required_ruby_version = ">= 2.0.0"


### PR DESCRIPTION
This PR replaces erikhuda/thor with rails/thor. It will clarify the repository location and reduce redundant http redirects.