### PR TITLE
Support latest did_you_mean

### DIFF
--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -102,9 +102,14 @@ class Thor
   end
 
   if Correctable
-    DidYouMean::SPELL_CHECKERS.merge!(
-      'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
-      'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
-    )
+    if DidYouMean.respond_to?(:correct_error)
+      DidYouMean.correct_error(Thor::UndefinedCommandError, UndefinedCommandError::SpellChecker)
+      DidYouMean.correct_error(Thor::UnknownArgumentError, UnknownArgumentError::SpellChecker)
+    else
+      DidYouMean::SPELL_CHECKERS.merge!(
+        'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
+        'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
+      )
+    end
   end
 end


### PR DESCRIPTION
Using `DidYouMean::SPELL_CHECKERS.merge!` has been deprecated.

Since this new version will be included with Ruby 3.1, I'm looking into supporting it without warnings.