### PR TITLE
Use DidYouMean.correct_error for better Ractor support

### DIFF
--- a/lib/thor/error.rb
+++ b/lib/thor/error.rb
@@ -102,9 +102,14 @@ class Thor
   end
 
   if Correctable
-    DidYouMean::SPELL_CHECKERS.merge!(
-      'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
-      'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
-    )
+    if DidYouMean.respond_to?(:correct_error)
+      DidYouMean.correct_error(Thor::UndefinedCommandError, UndefinedCommandError::SpellChecker)
+      DidYouMean.correct_error(Thor::UnknownArgumentError, UnknownArgumentError::SpellChecker)
+    else
+      DidYouMean::SPELL_CHECKERS.merge!(
+        'Thor::UndefinedCommandError' => UndefinedCommandError::SpellChecker,
+        'Thor::UnknownArgumentError' => UnknownArgumentError::SpellChecker
+      )
+    end
   end
 end


### PR DESCRIPTION
I was working on better Ractor support for DidYouMean for the last few days. As part of that I had to deprecate the direct access to `DidYouMean::SPELL_CHECKERS` due to the necessity to maintain shareable objects within the dependency. From the next version the `DidYouMean.correct_error` method should be used as a replacement. This PR replaces the old API with the new one and should fix [the build failures](https://github.com/ruby/ruby/runs/4606737424?check_suite_focus=true#step:16:5131) in the upstream Ruby.

Let me know if there is anything I can do to get this change in.