### PR TITLE
Fix matching when DidYouMean is enabled

### DIFF
--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -116,7 +116,15 @@ describe Thor::Options do
       expected = "Unknown switches \"--baz\""
       expected << "\nDid you mean?  \"--bar\"" if Thor::Correctable
 
-      expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError, expected)
+      # raise_error checks the original_message on the Error in this
+      # case, to account for Ruby 3.1 default enabling of DidYouMean?
+      # So use a custom error check rather than the raise_error
+      # matcher
+      begin
+        check_unknown!
+      rescue Thor::UnknownArgumentError => uae
+        expect(uae.message).to eq(expected)
+      end
     end
 
     it "skips leading non-switches" do


### PR DESCRIPTION
Because of the changes in Ruby 3.1 to enable DidYouMean for a subset of errors, in a way that is somewhat confusing in specs, rspec-expectations now matches against the `original_message`, if the Error responds to that method.  That avoids having to match the backtrace in these circumstances.

Unfortunately that causes specs like this one - where DidYouMean is being used intentionally - to fail the matcher.  This PR updates the spec to avoid use of the matcher.

With this change, specs are now green.

