### PR TITLE
Draft: Fix negated option value when followed by argument

### DIFF
--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -330,6 +330,10 @@ describe Thor::Options do
         expect(parse("--foo=false")["foo"]).to eq(false)
       end
 
+      it "accepts '--no-opt' variant with separator '--', setting false for value" do
+        expect(parse("--no-foo", "--")["foo"]).to eq(false)
+      end
+
       it "accepts --[no-]opt variant, setting false for value" do
         expect(parse("--no-foo")["foo"]).to eq(false)
       end


### PR DESCRIPTION
I'm facing a boolean option parsing error: when using negated option (e.g. `--no-foo`) followed by argument, the parsed value is not the expected one.

Context: In [modulesync](https://github.com/voxpupuli/modulesync), we use `thor`. I expect to contribute a new command to be used like this:
```
msync execute --no-fail-fast -- /path/to/script --script-option
```

But the `options` hash returned by `thor` after parsing this command line is:
```
{
"fail_fast" => true
}
```
Which is not the expected value ;-)

Please note that if `--no-fail-fast` option is the last one, its OK:
```
$ msync execute --no-fail-fast 
{
"fail_fast" => false
}
$ msync execute /path/to/script --no-fail-fast 
{
"fail_fast" => false
}
```

First, I commited a small test, attempting to target the problem.