### PR TITLE
fix options spec.

### DIFF
--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -116,7 +116,9 @@ describe Thor::Options do
       expected = "Unknown switches \"--baz\""
       expected << "\nDid you mean?  \"--bar\"" if Thor::Correctable
 
-      expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError, expected)
+      expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError) do |error|
+        expect(error.to_s).to eq(expected)
+      end
     end
 
     it "skips leading non-switches" do


### PR DESCRIPTION
 🌈  fix spec/parser/options_spec.rb:119 only (there are other CI failures on some rubies - will do independent PRs for those to fix)
