### PR TITLE
try coveralls_reborn to fix ssl errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 group :test do
   gem "childlabor"
-  gem "coveralls", ">= 0.8.19"
+  gem 'coveralls_reborn', '~> 0.23.1', require: false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
   gem "rspec", ">= 3.2"
   gem "rspec-mocks", ">= 3"
   gem "rubocop", "~> 0.50.0"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,13 +1,15 @@
 $TESTING = true
 
-require "simplecov"
-require "coveralls"
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+  require "simplecov"
+  require "coveralls"
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
 
-SimpleCov.start do
-  add_filter "/spec"
-  minimum_coverage(90)
+  SimpleCov.start do
+    add_filter "/spec"
+    minimum_coverage(90)
+  end
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))


### PR DESCRIPTION
Note that we could also use the coveralls action as recommended
in https://github.com/tagliala/coveralls-ruby-reborn
but it seems like a github token is needed, which makes
it more complex for contributors

This does mean dropping coveralls for EOLed rubies but
do we really need to post to coveralls on each test run?
Wouldn't one test run be enough?