### PR TITLE
Check if `type: array` values are in `enum`

### DIFF
--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -122,7 +122,15 @@ class Thor
     def parse_array(name)
       return shift if peek.is_a?(Array)
       array = []
-      array << shift while current_is_value?
+      while current_is_value?
+        value = shift
+        if !value.empty? && @switches.is_a?(Hash) && switch = @switches[name]
+          if switch.enum && !switch.enum.include?(value)
+            raise MalformattedArgumentError, "Expected all values of '#{name}' to be one of #{switch.enum.join(', ')}; got #{value}"
+          end
+        end
+        array << value
+      end
       array
     end
 

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -443,6 +443,13 @@ describe Thor::Options do
         create :attributes => Thor::Option.new("attributes", :type => :array, :repeatable => true)
         expect(parse("--attributes", "1", "2", "--attributes", "3", "4")["attributes"]).to eq([["1", "2"], ["3", "4"]])
       end
+
+      it "raises error when value isn't in enum" do
+        enum = %w(apple banana)
+        create :fruit => Thor::Option.new("fruits", :type => :array, :enum => enum)
+        expect { parse("--fruits=", "apple", "banana", "strawberry") }.to raise_error(Thor::MalformattedArgumentError,
+            "Expected all values of '--fruits' to be one of #{enum.join(', ')}; got strawberry")
+      end
     end
 
     describe "with :numeric type" do


### PR DESCRIPTION
🌈

### What are you trying to accomplish?

Fixes #783 

### What approach did you choose and why?

Extending the pattern done for `type: string` and `type: numeric`.

### What should reviewers focus on?

🤷 

### The impact of these changes

`enum` validation will be done for `type: array` option values.