### PR TITLE
Switch hash from MD5 to SHA256

### DIFF
--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -2,7 +2,7 @@ require_relative "../thor"
 require_relative "group"
 
 require "yaml"
-require "digest/md5"
+require "digest/sha2"
 require "pathname"
 
 class Thor::Runner < Thor #:nodoc: # rubocop:disable ClassLength
@@ -91,7 +91,7 @@ class Thor::Runner < Thor #:nodoc: # rubocop:disable ClassLength
     end
 
     thor_yaml[as] = {
-      :filename   => Digest::MD5.hexdigest(name + as),
+      :filename   => Digest::SHA256.hexdigest(name + as),
       :location   => location,
       :namespaces => Thor::Util.namespaces_in_content(contents, base)
     }

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -219,7 +219,7 @@ Usage: "thor my_script:animal TYPE"')
         allow(FileUtils).to receive(:touch)
         allow(Thor::LineEditor).to receive(:readline).and_return("Y")
 
-        path = File.join(Thor::Util.thor_root, Digest::MD5.hexdigest(@location + "random"))
+        path = File.join(Thor::Util.thor_root, Digest::SHA256.hexdigest(@location + "random"))
         expect(File).to receive(:open).with(path, "w")
       end
 


### PR DESCRIPTION
On FIPS-compliant systems (http://en.wikipedia.org/wiki/FIPS_140), MD5
cannot be used. Switch to SHA256 instead.

However, this change does not keep backward compatibility with systems
with already-installed Thor recipes.

Closes #287