### PR TITLE
CreateFile#identical? fixed for files containing multi-byte UTF-8 codepoints

### DIFF
--- a/lib/thor/actions/create_file.rb
+++ b/lib/thor/actions/create_file.rb
@@ -43,7 +43,7 @@ class Thor
       # Boolean:: true if it is identical, false otherwise.
       #
       def identical?
-        exists? && File.binread(destination) == render
+        exists? && File.binread(destination) == String.new(render).force_encoding("ASCII-8BIT")
       end
 
       # Holds the content to be added to the file.

--- a/lib/thor/actions/create_file.rb
+++ b/lib/thor/actions/create_file.rb
@@ -43,6 +43,7 @@ class Thor
       # Boolean:: true if it is identical, false otherwise.
       #
       def identical?
+        # binread uses ASCII-8BIT, so to avoid false negatives, the string must use the same
         exists? && File.binread(destination) == String.new(render).force_encoding("ASCII-8BIT")
       end
 

--- a/spec/actions/create_file_spec.rb
+++ b/spec/actions/create_file_spec.rb
@@ -7,11 +7,11 @@ describe Thor::Actions::CreateFile do
     ::FileUtils.rm_rf(destination_root)
   end
 
-  def create_file(destination = nil, config = {}, options = {})
+  def create_file(destination = nil, config = {}, options = {}, contents = "CONFIGURATION")
     @base = MyCounter.new([1, 2], options, :destination_root => destination_root)
     allow(@base).to receive(:file_name).and_return("rdoc")
 
-    @action = Thor::Actions::CreateFile.new(@base, destination, "CONFIGURATION", {:verbose => !@silence}.merge(config))
+    @action = Thor::Actions::CreateFile.new(@base, destination, contents, {:verbose => !@silence}.merge(config))
   end
 
   def invoke!
@@ -192,6 +192,13 @@ describe Thor::Actions::CreateFile do
   describe "#identical?" do
     it "returns true if the destination file exists and is identical" do
       create_file("doc/config.rb")
+      expect(@action.identical?).to be false
+      invoke!
+      expect(@action.identical?).to be true
+    end
+
+    it "returns true if the destination file exists and is identical and contains multi-byte UTF-8 codepoints" do
+      create_file("doc/config.rb", {}, {}, "€")
       expect(@action.identical?).to be false
       invoke!
       expect(@action.identical?).to be true


### PR DESCRIPTION
 🌈

Currently if you regenerate a file that contains a multi-byte UTF-8 codepoint (such as €) the file will falsely be identified as having changed. This PR adds a test to the create_file_spec to identify the problem, and then fixes the problem.

The change is the same as in https://github.com/rails/thor/pull/656, but that PR seems to have languished unmerged for just over 3yrs. I'm hoping the testing approach in the PR will address the previous objections so that the change can be merged.