### PR TITLE
Upgrade RuboCop, fix config and offenses, and run it in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Run linters
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: lint_gems.rb
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rubocop

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .yardoc
 Desktop.ini
 Gemfile.lock
+lint_gems.rb.lock
 Icon?
 InstalledFiles
 Session.vim

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,32 +6,38 @@ AllCops:
   Exclude:
     - spec/sandbox/**/*
     - spec/fixtures/**/*
+    - vendor/bundle/**/**
 
 # Enforce Ruby 1.8-compatible hash syntax
-HashSyntax:
+Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
 # No spaces inside hash literals
-SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
 # Enforce outdenting of access modifiers (i.e. public, private, protected)
-AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
-EmptyLinesAroundAccessModifier:
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 
 # Align ends correctly
-EndAlignment:
+Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
+  Exclude:
+    - 'lib/thor/actions.rb'
+    - 'lib/thor/error.rb'
+    - 'lib/thor/shell/basic.rb'
+    - 'lib/thor/parser/option.rb'
 
 # Indentation of when/else
-CaseIndentation:
+Layout/CaseIndentation:
   EnforcedStyle: end
   IndentOneStep: false
 
-StringLiterals:
+Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Lint/AssignmentInCondition:
@@ -39,16 +45,11 @@ Lint/AssignmentInCondition:
     - 'lib/thor/line_editor/readline.rb'
     - 'lib/thor/parser/arguments.rb'
 
-Lint/EndAlignment:
-  Exclude:
-    - 'lib/thor/actions.rb'
-    - 'lib/thor/parser/option.rb'
-
 Security/Eval:
   Exclude:
     - 'spec/helper.rb'
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Exclude:
     - 'lib/thor/line_editor/readline.rb'
 
@@ -99,10 +100,15 @@ Style/GlobalVars:
     - 'spec/register_spec.rb'
     - 'spec/thor_spec.rb'
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Style/MethodMissing:
+Lint/MissingSuper:
+  Exclude:
+    - 'lib/thor/error.rb'
+    - 'spec/rake_compat_spec.rb'
+
+Style/MissingRespondToMissing:
   Exclude:
     - 'lib/thor/core_ext/hash_with_indifferent_access.rb'
     - 'lib/thor/runner.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,14 +25,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'spec/actions_spec.rb'
     - 'spec/command_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleAlignWith, SupportedStylesAlignWith, AutoCorrect.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Lint/EndAlignment:
-  Exclude:
-    - 'lib/thor/error.rb'
-
 # Offense count: 65
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,9 @@ end
 
 group :test do
   gem "childlabor"
-  gem 'coveralls_reborn', '~> 0.23.1', require: false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+  gem 'coveralls_reborn', '~> 0.23.1', :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
   gem "rspec", ">= 3.2"
   gem "rspec-mocks", ">= 3"
-  gem "rubocop", "~> 0.50.0"
   gem "simplecov", ">= 0.13"
   gem "webmock"
 end

--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -356,7 +356,7 @@ class Thor
     end
 
     # The method responsible for dispatching given the args.
-    def dispatch(meth, given_args, given_opts, config) #:nodoc: # rubocop:disable MethodLength
+    def dispatch(meth, given_args, given_opts, config) #:nodoc:
       meth ||= retrieve_command_name(given_args)
       command = all_commands[normalize_command_name(meth)]
 

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -610,7 +610,7 @@ class Thor
       def find_and_refresh_command(name) #:nodoc:
         if commands[name.to_s]
           commands[name.to_s]
-        elsif command = all_commands[name.to_s] # rubocop:disable AssignmentInCondition
+        elsif command = all_commands[name.to_s] # rubocop:disable Lint/AssignmentInCondition
           commands[name.to_s] = command.clone
         else
           raise ArgumentError, "You supplied :for => #{name.inspect}, but the command #{name.inspect} could not be found."

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -169,7 +169,7 @@ class Thor::Group
     # options are added to group_options hash. Options that already exists
     # in base_options are not added twice.
     #
-    def get_options_from_invocations(group_options, base_options) #:nodoc: # rubocop:disable MethodLength
+    def get_options_from_invocations(group_options, base_options) #:nodoc:
       invocations.each do |name, from_option|
         value = if from_option
           option = class_options[name]

--- a/lib/thor/parser/arguments.rb
+++ b/lib/thor/parser/arguments.rb
@@ -1,5 +1,5 @@
 class Thor
-  class Arguments #:nodoc: # rubocop:disable ClassLength
+  class Arguments #:nodoc:
     NUMERIC = /[-+]?(\d*\.\d+|\d+)/
 
     # Receives an array of args and returns two arrays, one with arguments

--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -58,7 +58,7 @@ class Thor
         default = nil
         if VALID_TYPES.include?(value)
           value
-        elsif required = (value == :required) # rubocop:disable AssignmentInCondition
+        elsif required = (value == :required) # rubocop:disable Lint/AssignmentInCondition
           :string
         end
       when TrueClass, FalseClass

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -1,5 +1,5 @@
 class Thor
-  class Options < Arguments #:nodoc: # rubocop:disable ClassLength
+  class Options < Arguments #:nodoc:
     LONG_RE     = /^(--\w+(?:-\w+)*)$/
     SHORT_RE    = /^(-[a-z])$/i
     EQ_RE       = /^(--\w+(?:-\w+)*|-[a-z])=(.*)$/i
@@ -85,7 +85,7 @@ class Thor
       super(arg)
     end
 
-    def parse(args) # rubocop:disable MethodLength
+    def parse(args) # rubocop:disable Metrics/MethodLength
       @pile = args.dup
       @is_treated_as_value = false
       @parsing_options = true
@@ -101,7 +101,7 @@ class Thor
               unshift($1.split("").map { |f| "-#{f}" })
               next
             when EQ_RE
-              unshift($2, is_value: true)
+              unshift($2, :is_value => true)
               switch = $1
             when SHORT_NUM
               unshift($2)
@@ -194,7 +194,7 @@ class Thor
     end
 
     def switch_option(arg)
-      if match = no_or_skip?(arg) # rubocop:disable AssignmentInCondition
+      if match = no_or_skip?(arg) # rubocop:disable Lint/AssignmentInCondition
         @switches[arg] || @switches["--#{match}"]
       else
         @switches[arg]

--- a/lib/thor/rake_compat.rb
+++ b/lib/thor/rake_compat.rb
@@ -41,7 +41,7 @@ instance_eval do
   def task(*)
     task = super
 
-    if klass = Thor::RakeCompat.rake_classes.last # rubocop:disable AssignmentInCondition
+    if klass = Thor::RakeCompat.rake_classes.last # rubocop:disable Lint/AssignmentInCondition
       non_namespaced_name = task.name.split(":").last
 
       description = non_namespaced_name
@@ -59,7 +59,7 @@ instance_eval do
   end
 
   def namespace(name)
-    if klass = Thor::RakeCompat.rake_classes.last # rubocop:disable AssignmentInCondition
+    if klass = Thor::RakeCompat.rake_classes.last # rubocop:disable Lint/AssignmentInCondition
       const_name = Thor::Util.camel_case(name.to_s).to_sym
       klass.const_set(const_name, Class.new(Thor))
       new_klass = klass.const_get(const_name)

--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -5,7 +5,7 @@ require "yaml"
 require "digest/md5"
 require "pathname"
 
-class Thor::Runner < Thor #:nodoc: # rubocop:disable ClassLength
+class Thor::Runner < Thor #:nodoc:
   autoload :OpenURI, "open-uri"
 
   map "-T" => :list, "-i" => :install, "-u" => :update, "-v" => :version
@@ -45,7 +45,7 @@ class Thor::Runner < Thor #:nodoc: # rubocop:disable ClassLength
 
   desc "install NAME", "Install an optionally named Thor file into your system commands"
   method_options :as => :string, :relative => :boolean, :force => :boolean
-  def install(name) # rubocop:disable MethodLength
+  def install(name) # rubocop:disable Metrics/MethodLength
     initialize_thorfiles
 
     # If a directory name is provided as the argument, look for a 'main.thor'

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -182,7 +182,7 @@ class Thor
       # indent<Integer>:: Indent the first column by indent value.
       # colwidth<Integer>:: Force the first column to colwidth spaces wide.
       #
-      def print_table(array, options = {}) # rubocop:disable MethodLength
+      def print_table(array, options = {}) # rubocop:disable Metrics/MethodLength
         return if array.empty?
 
         formats = []

--- a/lib/thor/util.rb
+++ b/lib/thor/util.rb
@@ -90,7 +90,7 @@ class Thor
       def snake_case(str)
         return str.downcase if str =~ /^[A-Z_]+$/
         str.gsub(/\B[A-Z]/, '_\&').squeeze("_") =~ /_*(.*)/
-        $+.downcase
+        Regexp.last_match(-1).downcase
       end
 
       # Receives a string and convert it to camel case. camel_case returns CamelCase.
@@ -189,7 +189,7 @@ class Thor
       # Returns the root where thor files are located, depending on the OS.
       #
       def thor_root
-        File.join(user_home, ".thor").tr('\\', "/")
+        File.join(user_home, ".thor").tr("\\", "/")
       end
 
       # Returns the files in the thor root. On Windows thor_root will be something
@@ -236,7 +236,7 @@ class Thor
                 # symlink points to 'ruby_install_name'
                 ruby = alternate_ruby if linked_ruby == ruby_name || linked_ruby == ruby
               end
-            rescue NotImplementedError # rubocop:disable HandleExceptions
+            rescue NotImplementedError # rubocop:disable Lint/HandleExceptions
               # just ignore on windows
             end
           end

--- a/lint_gems.rb
+++ b/lint_gems.rb
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rubocop", "~> 1.30"

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -319,7 +319,7 @@ describe Thor::Actions do
           end
 
           it "does not replace if pretending" do
-            runner({ :pretend => true }, :revoke)
+            runner({:pretend => true}, :revoke)
             action :gsub_file, "doc/README", "__start__", "START"
             expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
           end
@@ -349,7 +349,7 @@ describe Thor::Actions do
           end
 
           it "does not replace if pretending" do
-            runner({ :pretend => true }, :revoke)
+            runner({:pretend => true}, :revoke)
             action :gsub_file, "doc/README", "__start__", "START", :force => true
             expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
           end

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -63,53 +63,53 @@ describe Thor::Shell::Basic do
     end
 
     it "prints a message to the user and does not echo stdin if the echo option is set to false" do
-      expect($stdout).to receive(:print).with('What\'s your password? ')
+      expect($stdout).to receive(:print).with("What's your password? ")
       expect($stdin).to receive(:noecho).and_return("mysecretpass")
       expect(shell.ask("What's your password?", :echo => false)).to eq("mysecretpass")
     end
 
     it "prints a message to the user with the available options, expects case-sensitive matching, and determines the correctness of the answer" do
       flavors = %w(strawberry chocolate vanilla)
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', {:limited_to => flavors}).and_return("chocolate")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ", {:limited_to => flavors}).and_return("chocolate")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => flavors)).to eq("chocolate")
     end
 
     it "prints a message to the user with the available options, expects case-sensitive matching, and reasks the question after an incorrect response" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', {:limited_to => flavors}).and_return("moose tracks", "chocolate")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ", {:limited_to => flavors}).and_return("moose tracks", "chocolate")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => flavors)).to eq("chocolate")
     end
 
     it "prints a message to the user with the available options, expects case-sensitive matching, and reasks the question after a case-insensitive match" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', {:limited_to => flavors}).and_return("cHoCoLaTe", "chocolate")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors)).to eq("chocolate")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ", {:limited_to => flavors}).and_return("cHoCoLaTe", "chocolate")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => flavors)).to eq("chocolate")
     end
 
     it "prints a message to the user with the available options, expects case-insensitive matching, and determines the correctness of the answer" do
       flavors = %w(strawberry chocolate vanilla)
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', {:limited_to => flavors, :case_insensitive => true}).and_return("CHOCOLATE")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ", {:limited_to => flavors, :case_insensitive => true}).and_return("CHOCOLATE")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
     end
 
     it "prints a message to the user with the available options, expects case-insensitive matching, and reasks the question after an incorrect response" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ', {:limited_to => flavors, :case_insensitive => true}).and_return("moose tracks", "chocolate")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] ", {:limited_to => flavors, :case_insensitive => true}).and_return("moose tracks", "chocolate")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :limited_to => flavors, :case_insensitive => true)).to eq("chocolate")
     end
 
     it "prints a message to the user containing a default and sets the default if only enter is pressed" do
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? (vanilla) ', {:default => "vanilla"}).and_return("")
-      expect(shell.ask('What\'s your favorite Neopolitan flavor?', :default => "vanilla")).to eq("vanilla")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? (vanilla) ", {:default => "vanilla"}).and_return("")
+      expect(shell.ask("What's your favorite Neopolitan flavor?", :default => "vanilla")).to eq("vanilla")
     end
 
     it "prints a message to the user with the available options and reasks the question after an incorrect response and then returns the default" do
       flavors = %w(strawberry chocolate vanilla)
       expect($stdout).to receive(:print).with("Your response must be one of: [strawberry, chocolate, vanilla]. Please try again.\n")
-      expect(Thor::LineEditor).to receive(:readline).with('What\'s your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] (vanilla) ', {:default => "vanilla", :limited_to => flavors}).and_return("moose tracks", "")
+      expect(Thor::LineEditor).to receive(:readline).with("What's your favorite Neopolitan flavor? [strawberry, chocolate, vanilla] (vanilla) ", {:default => "vanilla", :limited_to => flavors}).and_return("moose tracks", "")
       expect(shell.ask("What's your favorite Neopolitan flavor?", :default => "vanilla", :limited_to => flavors)).to eq("vanilla")
     end
   end
@@ -400,7 +400,7 @@ TABLE
 
     it "prints a table with small numbers and right-aligns them" do
       table = [
-        ["Name", "Number", "Color"], # rubocop: disable WordArray
+        ["Name", "Number", "Color"], # rubocop: disable Style/WordArray
         ["Erik", 1, "green"]
       ]
       content = capture(:stdout) { shell.print_table(table) }
@@ -412,7 +412,7 @@ TABLE
 
     it "doesn't output extra spaces for right-aligned columns in the last column" do
       table = [
-        ["Name", "Number"], # rubocop: disable WordArray
+        ["Name", "Number"], # rubocop: disable Style/WordArray
         ["Erik", 1]
       ]
       content = capture(:stdout) { shell.print_table(table) }
@@ -424,7 +424,7 @@ TABLE
 
     it "prints a table with big numbers" do
       table = [
-        ["Name", "Number", "Color"], # rubocop: disable WordArray
+        ["Name", "Number", "Color"], # rubocop: disable Style/WordArray
         ["Erik", 1_234_567_890_123, "green"]
       ]
       content = capture(:stdout) { shell.print_table(table) }


### PR DESCRIPTION
I noticed that even if the code includes RuboCop inline comments disabling cops, RuboCop is (no longer?) run in CI.

This PR upgrades RuboCop, fixes configuration and issues, and runs it in CI.

It does not change any styles that were not previously configured.