### PR TITLE
Respect the updated NO_COLOR specification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ group :test do
   gem "rspec", ">= 3.2"
   gem "rspec-mocks", ">= 3"
   gem "simplecov", ">= 0.13"
-  gem "webmock"
+  gem "webmock", '~> 3.14.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
+  gem "webmock", '>= 3.14' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
 end
 
 gemspec

--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -105,7 +105,7 @@ class Thor
       end
 
       def are_colors_disabled?
-        !ENV['NO_COLOR'].nil?
+        !ENV['NO_COLOR'].nil? && !ENV['NO_COLOR'].empty?
       end
 
       # Overwrite show_diff to show diff with colors if Diff::LCS is


### PR DESCRIPTION
Since implementation the NO_COLOR specification has changed. Previously
if NO_COLOR was set in the environment it should be respected regardless
of value. In the new updated specification NO_COLOR should only be
respected if set to any non-empty string.

See this comment thread on the original commit for more information.
https://github.com/rails/thor/commit/21e65684432c0fcc975c1d6fda497da24149f763#r80414525

Fixes #795