### PR TITLE
Remove support for deprecated OS

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -425,7 +425,7 @@ class Thor
       end
 
       def unix?
-        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix|hpux)/i
+        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix)/i
       end
 
       def truncate(string, width)

--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -425,7 +425,7 @@ class Thor
       end
 
       def unix?
-        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris|irix)/i
+        RUBY_PLATFORM =~ /(aix|darwin|linux|(net|free|open)bsd|cygwin|solaris)/i
       end
 
       def truncate(string, width)


### PR DESCRIPTION
- Support for HP-UX was dropped in ruby/ruby#5457.
- The IRIX OS is no longer maintained with the last release being 16 years ago.