### PR TITLE
Update error message for content already exists case.

### DIFF
--- a/lib/thor/actions/inject_into_file.rb
+++ b/lib/thor/actions/inject_into_file.rb
@@ -21,7 +21,7 @@ class Thor
     #     gems.split(" ").map{ |gem| "  config.gem :#{gem}" }.join("\n")
     #   end
     #
-    WARNINGS = { unchanged_no_flag: 'File unchanged! The supplied flag value not found!' }
+    WARNINGS = { unchanged_no_flag: 'File unchanged! Either the supplied flag value not found or the content has already been inserted!' }
 
     def insert_into_file(destination, *args, &block)
       data = block_given? ? block : args.shift


### PR DESCRIPTION
🌈 The `replace! ` method fails if the flag is not found OR if the text is already present.  The error message only says that the flag has not been found.   This is incorrect/misleading in the case where it has actually failed because the content is already present.  This is pr just adds that to the error message.

Alternatively, could add a separate error message, change the return value from `replace!` to indicate the type of error but this seems like overkill.
