### PR TITLE
Fix dashless option usage info

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -11,7 +11,7 @@ class Thor
       super
       @lazy_default   = options[:lazy_default]
       @group          = options[:group].to_s.capitalize if options[:group]
-      @aliases        = Array(options[:aliases])
+      @aliases        = normalize_aliases(options[:aliases])
       @hide           = options[:hide]
     end
 
@@ -154,6 +154,12 @@ class Thor
 
     def dasherize(str)
       (str.length > 1 ? "--" : "-") + str.tr("_", "-")
+    end
+
+  private
+
+    def normalize_aliases(aliases)
+      Array(aliases).map { |short| short.to_s.sub(/^(?!\-)/, "-") }
     end
   end
 end

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -50,8 +50,7 @@ class Thor
       options.each do |option|
         @switches[option.switch_name] = option
 
-        option.aliases.each do |short|
-          name = short.to_s.sub(/^(?!\-)/, "-")
+        option.aliases.each do |name|
           @shorts[name] ||= option.switch_name
         end
       end

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -108,8 +108,8 @@ describe Thor::Option do
         expect(parse([:foo, :b, "--bar"], true).name).to eq("foo")
       end
 
-      it "sets all other items as aliases" do
-        expect(parse([:foo, :b, "--bar"], true).aliases).to eq([:b, "--bar"])
+      it "sets all other items as normalized aliases" do
+        expect(parse([:foo, :b, "--bar"], true).aliases).to eq(["-b", "--bar"])
       end
     end
   end
@@ -258,6 +258,10 @@ describe Thor::Option do
 
       it "does not negate the aliases" do
         expect(parse([:foo, "-f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo]")
+      end
+
+      it "normalizes the aliases" do
+        expect(parse([:foo, :f, "-b"], :required).usage).to eq("-f, -b, --foo=FOO")
       end
     end
   end

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -105,11 +105,11 @@ describe Thor::Option do
 
     describe "with key as an array" do
       it "sets the first items in the array to the name" do
-        expect(parse([:foo, :bar, :baz], true).name).to eq("foo")
+        expect(parse([:foo, :b, "--bar"], true).name).to eq("foo")
       end
 
       it "sets all other items as aliases" do
-        expect(parse([:foo, :bar, :baz], true).aliases).to eq([:bar, :baz])
+        expect(parse([:foo, :b, "--bar"], true).aliases).to eq([:b, "--bar"])
       end
     end
   end


### PR DESCRIPTION
🌈

When option aliases are specified without dashes

```ruby
option :from, aliases: [:f]
```

they are correctly handled when parsing the command

```
my_cli hello -f Loki Thor
from: Loki
Hello Thor
```

However the usage information does not include the dash. This PR fixes that by moving alias normalization to happen sooner, so it applies to both the usage information generator and the actual command:

```diff
 my_cli help hello  
 Usage:
   my_cli hello NAME

 Options:
-  f, [--from=FROM]  
+  -f, [--from=FROM]  

 say hello to NAME
```