### PR TITLE
Add support for providing http headers to get

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -66,11 +66,14 @@ class Thor
     # ==== Parameters
     # source<String>:: the address of the given content.
     # destination<String>:: the relative path to the destination root.
-    # config<Hash>:: give :verbose => false to not log the status.
+    # config<Hash>:: give :verbose => false to not log the status, and
+    #                :http_headers => <Hash> to add headers to an http request.
     #
     # ==== Examples
     #
     #   get "http://gist.github.com/103208", "doc/README"
+    #
+    #   get "http://gist.github.com/103208", "doc/README", :http_headers => {"Content-Type" => "application/json"}
     #
     #   get "http://gist.github.com/103208" do |content|
     #     content.split("\n").first
@@ -82,7 +85,7 @@ class Thor
 
       render = if source =~ %r{^https?\://}
         require "open-uri"
-        URI.send(:open, source) { |input| input.binmode.read }
+        URI.send(:open, source, config.fetch(:http_headers, {})) { |input| input.binmode.read }
       else
         source = File.expand_path(find_in_source_paths(source.to_s))
         open(source) { |input| input.binmode.read }

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -159,6 +159,16 @@ describe Thor::Actions do
         expect(content).to eq(body)
       end
     end
+
+    it "accepts http headers" do
+      body = "__start__\nHTTPFILE\n__end__\n"
+      headers = {"Content-Type" => "application/json"}
+      stub_request(:get, "https://example.com/file.txt").with(:headers => headers).to_return(:body => body.dup)
+      action :get, "https://example.com/file.txt", {:http_headers => headers} do |content|
+        expect(a_request(:get, "https://example.com/file.txt")).to have_been_made
+        expect(content).to eq(body)
+      end
+    end
   end
 
   describe "#template" do


### PR DESCRIPTION
🌈

Sometimes we want to use `get` to make requests to an API or endpoint that requires certain headers to be present (such as auth).

[OpenURI](https://ruby-doc.org/stdlib-3.1.2/libdoc/open-uri/rdoc/OpenURI.html) supports providing headers for the request, we just need to have a way of providing them.

This PR adds `:http_headers` as a config option to `get`, and is essentially just passed directly to `URI.open`.

Hopefully the test coverage and documentation is sufficient.

❤️💜💚💙💛 