### PR TITLE
Prefer to use URI.open and File.open instead of Kernel.open

### DIFF
--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -225,7 +225,7 @@ class Thor
         require "open-uri"
         URI.open(path, "Accept" => "application/x-thor-template", &:read)
       else
-        open(path, &:read)
+        File.open(path, &:read)
       end
 
       instance_eval(contents, path)

--- a/lib/thor/actions.rb
+++ b/lib/thor/actions.rb
@@ -223,7 +223,8 @@ class Thor
 
       contents = if is_uri
         require "open-uri"
-        URI.open(path, "Accept" => "application/x-thor-template", &:read)
+        # for ruby 2.1-2.4
+        URI.send(:open, path, "Accept" => "application/x-thor-template", &:read)
       else
         File.open(path, &:read)
       end

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -85,7 +85,7 @@ class Thor
         URI.send(:open, source) { |input| input.binmode.read }
       else
         source = File.expand_path(find_in_source_paths(source.to_s))
-        open(source) { |input| input.binmode.read }
+        File.open(source) { |input| input.binmode.read }
       end
 
       destination ||= if block_given?

--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -64,11 +64,12 @@ class Thor::Runner < Thor #:nodoc:
         if File.directory?(File.expand_path(name))
           base = File.join(name, "main.thor")
           package = :directory
-          contents = open(base, &:read)
+          contents = File.open(base, &:read)
         else
           base = name
           package = :file
-          contents = open(name, &:read)
+          require "open-uri"
+          contents = URI.send(:open, name, &:read) # for ruby 2.1-2.4
         end
       rescue Errno::ENOENT
         raise Error, "Error opening file '#{name}'"

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -234,7 +234,7 @@ describe Thor::Actions do
       allow(@template).to receive(:read).and_return(@template)
 
       @file = "/"
-      allow(runner).to receive(:open).and_return(@template)
+      allow(File).to receive(:open).and_return(@template)
     end
 
     it "accepts a URL as the path" do
@@ -255,7 +255,7 @@ describe Thor::Actions do
 
     it "accepts a local file path with spaces" do
       @file = File.expand_path("fixtures/path with spaces", File.dirname(__FILE__))
-      expect(runner).to receive(:open).with(@file).and_return(@template)
+      expect(File).to receive(:open).with(@file).and_return(@template)
       action(:apply, @file)
     end
 


### PR DESCRIPTION
👋  CodeQL detects "Use of `Kernel.open` or `IO.read` with a non-constant value" warnings in https://github.com/ruby/ruby. I hope to suppress them.