### PR TITLE
CI against Ruby 3.2 (and 2.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head]
+        ruby: ['2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head]
+        ruby: [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem "simplecov", ">= 0.13"
   gem "webmock", '~> 3.14.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
   gem "webmock", '>= 3.14' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.0")
+  gem "rexml", '3.2.4' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
 end
 
 gemspec


### PR DESCRIPTION
This patch adds CI configuration for Ruby 3.2.

Also, I noticed that the CI matrix includes Ruby `2.0` that would be parsed as integer `2` in GH actions. This means that Ruby 2.0 has never been tested on GH actions. I fixed this to be quoted `'2.0'`, and brought Ruby 2.0 testing back.