### PR TITLE
Support `Thor::CoreExt::HashWithIndifferentAccess#slice` method

### DIFF
--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -38,6 +38,10 @@ class Thor
         super(convert_key(key), *args)
       end
 
+      def slice(*keys)
+        super(*keys.map{ convert_key(_1) })
+      end
+
       def key?(key)
         super(convert_key(key))
       end

--- a/lib/thor/core_ext/hash_with_indifferent_access.rb
+++ b/lib/thor/core_ext/hash_with_indifferent_access.rb
@@ -39,7 +39,7 @@ class Thor
       end
 
       def slice(*keys)
-        super(*keys.map{ convert_key(_1) })
+        super(*keys.map{ |key| convert_key(key) })
       end
 
       def key?(key)

--- a/spec/core_ext/hash_with_indifferent_access_spec.rb
+++ b/spec/core_ext/hash_with_indifferent_access_spec.rb
@@ -40,6 +40,20 @@ describe Thor::CoreExt::HashWithIndifferentAccess do
     expect(@hash.fetch(:missing, :found)).to eq(:found)
   end
 
+  it "supports slice" do
+    expect(@hash.slice("foo")).to eq({"foo" => "bar"})
+    expect(@hash.slice(:foo)).to eq({"foo" => "bar"})
+
+    expect(@hash.slice("baz")).to eq({"baz" => "bee"})
+    expect(@hash.slice(:baz)).to eq({"baz" => "bee"})
+
+    expect(@hash.slice("foo", "baz")).to eq({"foo" => "bar", "baz" => "bee"})
+    expect(@hash.slice(:foo, :baz)).to eq({"foo" => "bar", "baz" => "bee"})
+
+    expect(@hash.slice("missing")).to eq({})
+    expect(@hash.slice(:missing)).to eq({})
+  end
+
   it "has key checkable by either strings or symbols" do
     expect(@hash.key?("foo")).to be true
     expect(@hash.key?(:foo)).to be true


### PR DESCRIPTION
resolve https://github.com/rails/thor/issues/804

This PR supports `Thor::CoreExt::HashWithIndifferentAccess#slice`.
```ruby
hash = Thor::CoreExt::HashWithIndifferentAccess.new 'foo' => 'bar', 'baz' => "bee"
hash.slice('foo')
# => {"foo"=>"bar"}
hash.slice(:foo)
# => {"foo"=>"bar"}
```
Thank you. 🌈