### PR TITLE
Allow force-enabling colors

### DIFF
--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -97,7 +97,7 @@ class Thor
     protected
 
       def can_display_colors?
-        are_colors_supported? && !are_colors_disabled?
+        ENV['FORCE_COLOR'].present? || (are_colors_supported? && !are_colors_disabled?)
       end
 
       def are_colors_supported?


### PR DESCRIPTION
Useful for places such as GitHub actions where you want colour, but are not in a TTY