### PR TITLE
Add support for printing tables with borders

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -175,6 +175,7 @@ class Thor
       # ==== Options
       # indent<Integer>:: Indent the first column by indent value.
       # colwidth<Integer>:: Force the first column to colwidth spaces wide.
+      # borders<Boolean>:: Adds ascii borders.
       #
       def print_table(array, options = {}) # rubocop:disable Metrics/MethodLength
         printer = TablePrinter.new(stdout, options)

--- a/lib/thor/shell/table_printer.rb
+++ b/lib/thor/shell/table_printer.rb
@@ -4,12 +4,15 @@ require_relative "terminal"
 class Thor
   module Shell
     class TablePrinter < ColumnPrinter
+      BORDER_SEPARATOR = :separator
+
       def initialize(stdout, options = {})
         super
         @formats = []
         @maximas = []
         @colwidth = options[:colwidth]
         @truncate = options[:truncate] == true ? Terminal.terminal_width : options[:truncate]
+        @padding = 1
       end
 
       def print(array)
@@ -17,33 +20,33 @@ class Thor
 
         prepare(array)
 
+        print_border_separator if options[:borders]
+
         array.each do |row|
+          if options[:borders] && row == BORDER_SEPARATOR
+            print_border_separator
+            next
+          end
+
           sentence = "".dup
 
           row.each_with_index do |column, index|
-            maxima = @maximas[index]
-
-            f = if column.is_a?(Numeric)
-              if index == row.size - 1
-                # Don't output 2 trailing spaces when printing the last column
-                "%#{maxima}s"
-              else
-                "%#{maxima}s  "
-              end
-            else
-              @formats[index]
-            end
-            sentence << f % column.to_s
+            sentence << format_cell(column, row.size, index)
           end
 
           sentence = truncate(sentence)
+          sentence << "|" if options[:borders]
           stdout.puts sentence
+
         end
+        print_border_separator if options[:borders]
       end
 
     private
 
       def prepare(array)
+        array = array.reject{|row| row == BORDER_SEPARATOR }
+
         @formats << "%-#{@colwidth + 2}s".dup if @colwidth
         start = @colwidth ? 1 : 0
 
@@ -51,8 +54,11 @@ class Thor
 
         start.upto(colcount - 1) do |index|
           maxima = array.map { |row| row[index] ? row[index].to_s.size : 0 }.max
+
           @maximas << maxima
-          @formats << if index == colcount - 1
+          @formats << if options[:borders]
+             "%-#{maxima}s".dup
+          elsif index == colcount - 1
             # Don't output 2 trailing spaces when printing the last column
             "%-s".dup
           else
@@ -62,6 +68,37 @@ class Thor
 
         @formats[0] = @formats[0].insert(0, " " * @indent)
         @formats << "%s"
+      end
+
+      def format_cell(column, row_size, index)
+        maxima = @maximas[index]
+
+        f = if column.is_a?(Numeric)
+          if options[:borders]
+            # With borders we handle padding separately
+            "%#{maxima}s"
+          elsif index == row_size - 1
+            # Don't output 2 trailing spaces when printing the last column
+            "%#{maxima}s"
+          else
+            "%#{maxima}s  "
+          end
+        else
+          @formats[index]
+        end
+
+        cell = "".dup
+        cell << "|" + " " * @padding if options[:borders]
+        cell << f % column.to_s
+        cell << " " * @padding if options[:borders]
+        cell
+      end
+
+      def print_border_separator
+        top = @maximas.map do |maxima|
+          " " * @indent + "+" + "-" * (maxima + 2 * @padding)
+        end
+        stdout.puts top.join + "+"
       end
 
       def truncate(string)

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -432,6 +432,44 @@ Name  Number         Color
 Erik  1234567890123  green
       TABLE
     end
+
+    it "prints a table with borders" do
+      content = capture(:stdout) { shell.print_table(@table, borders: true) }
+      expect(content).to eq(<<-TABLE)
++-----+------+-------------+
+| abc | #123 | first three |
+|     | #0   | empty       |
+| xyz | #786 | last three  |
++-----+------+-------------+
+TABLE
+    end
+
+    it "prints a table with borders and separators" do
+      @table.insert(1, :separator)
+      content = capture(:stdout) { shell.print_table(@table, borders: true) }
+      expect(content).to eq(<<-TABLE)
++-----+------+-------------+
+| abc | #123 | first three |
++-----+------+-------------+
+|     | #0   | empty       |
+| xyz | #786 | last three  |
++-----+------+-------------+
+TABLE
+    end
+
+    it "prints a table with borders and small numbers and right-aligns them" do
+      table = [
+        ["Name", "Number", "Color"], # rubocop: disable Style/WordArray
+        ["Erik", 1, "green"]
+      ]
+      content = capture(:stdout) { shell.print_table(table, borders: true) }
+      expect(content).to eq(<<-TABLE)
++------+--------+-------+
+| Name | Number | Color |
+| Erik |      1 | green |
++------+--------+-------+
+TABLE
+    end
   end
 
   describe "#file_collision" do


### PR DESCRIPTION
Adding borders to tables can improve their legibility.

_Before_
```
  Name  Number  Color
  Erik       1  green
  Ruby       2  red 
```

_After with `borders: true`_
```
+------+--------+-------+
| Name | Number | Color |
+------+--------+-------+
| Erik |      1 | green |
| Ruby |      2 | red   |
+------+--------+-------+
```

This would allow replacing the [custom table](https://github.com/rails/rails/blob/4e01a7e8753c30e22264e185082524a9ea5e0c90/railties/lib/rails/code_statistics.rb#L81-L116) for code statistics in
Rails, with the generic implementation in Thor.

By adding :separators to a table a horizontal separator will be added.
This functionality was inspired by: https://github.com/piotrmurach/tty-table
Having the ability to add separators where required adds more flexibility instead of having headers and footers.

Builds on: https://github.com/rails/thor/pull/854