### PR TITLE
Validate arguments for `method_option` and `class_option`

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -141,7 +141,7 @@ class Thor
     #     # magic
     #   end
     #
-    #   method_option :foo => :bar, :for => :previous_command
+    #   method_option :foo, :for => :previous_command
     #
     #   def next_command
     #     # magic
@@ -161,6 +161,9 @@ class Thor
     # :hide     - If you want to hide this option from the help.
     #
     def method_option(name, options = {})
+      unless [ Symbol, String ].any? { |klass| name.is_a?(klass) }
+        raise ArgumentError, "Expected a Symbol or String, got #{name.inspect}"
+      end
       scope = if options[:for]
         find_and_refresh_command(options[:for]).options
       else

--- a/lib/thor/base.rb
+++ b/lib/thor/base.rb
@@ -326,6 +326,9 @@ class Thor
       # :hide::     -- If you want to hide this option from the help.
       #
       def class_option(name, options = {})
+        unless [ Symbol, String ].any? { |klass| name.is_a?(klass) }
+          raise ArgumentError, "Expected a Symbol or String, got #{name.inspect}"
+        end
         build_option(name, options, class_options)
       end
 

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -750,6 +750,22 @@ HELP
       expect(klass.start(%w(hi --loud jose))).to eq("Hi JOSE")
     end
 
+    it "method_option raises an ArgumentError if name is not a Symbol or String" do
+      expect do
+        Class.new(Thor) do
+          method_option loud: true, type: :boolean
+        end
+      end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")
+    end
+
+    it "class_option raises an ArgumentError if name is not a Symbol or String" do
+      expect do
+        Class.new(Thor) do
+          class_option loud: true, type: :boolean
+        end
+      end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")
+    end
+
     it "passes through unknown options" do
       klass = Class.new(Thor) do
         desc "unknown", "passing unknown options"


### PR DESCRIPTION
`method_option` and `class_option` require a String or Symbol as the first argument.
This can be somewhat confusing when `method_options` and `class_options` require a Hash as argument.

Fixes #808