### PR TITLE
Fix help for file_collision method without block

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -316,7 +316,7 @@ class Thor
 
             say "Please specify merge tool to `THOR_MERGE` env."
           else
-            say file_collision_help
+            say file_collision_help(block_given?)
           end
         end
       end
@@ -384,16 +384,21 @@ class Thor
         end
       end
 
-      def file_collision_help #:nodoc:
-        <<-HELP
+      def file_collision_help(block_given) #:nodoc:
+        help = <<-HELP
         Y - yes, overwrite
         n - no, do not overwrite
         a - all, overwrite this and all others
         q - quit, abort
-        d - diff, show the differences between the old and the new
         h - help, show this help
-        m - merge, run merge tool
         HELP
+        if block_given
+          help << <<-HELP
+        d - diff, show the differences between the old and the new
+        m - merge, run merge tool
+          HELP
+        end
+        help
       end
 
       def show_diff(destination, content) #:nodoc:


### PR DESCRIPTION
Fix https://github.com/rails/thor/issues/818

Branch help for file_collision depending on block_given.

This will change the order of the help slightly, but probably not a problem.

When I ran the sample code described in the issue(#818), it looked like this:
```shell
$ ruby ./thor.rb hello
=== file_collision with no block
Overwrite ./foo.txt? (enter "h" for help) [Ynaqh] h
        Y - yes, overwrite
        n - no, do not overwrite
        a - all, overwrite this and all others
        q - quit, abort
        h - help, show this help
Overwrite ./foo.txt? (enter "h" for help) [Ynaqh] y
=== file_collision with block
Overwrite ./foo.txt? (enter "h" for help) [Ynaqdhm] h
        Y - yes, overwrite
        n - no, do not overwrite
        a - all, overwrite this and all others
        q - quit, abort
        h - help, show this help
        d - diff, show the differences between the old and the new
        m - merge, run merge tool
Overwrite ./foo.txt? (enter "h" for help) [Ynaqdhm] d
- file_collision with no block
+ file_collision with block
Retrying...
Overwrite ./foo.txt? (enter "h" for help) [Ynaqdhm] y
```