### PR TITLE
Improve the code documentation with indentation

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -67,15 +67,15 @@ class Thor
       # Readline.
       #
       # ==== Example
-      # ask("What is your name?")
+      #   ask("What is your name?")
       #
-      # ask("What is the planet furthest from the sun?", :default => "Pluto")
+      #   ask("What is the planet furthest from the sun?", :default => "Neptune")
       #
-      # ask("What is your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"])
+      #   ask("What is your favorite Neopolitan flavor?", :limited_to => ["strawberry", "chocolate", "vanilla"])
       #
-      # ask("What is your password?", :echo => false)
+      #   ask("What is your password?", :echo => false)
       #
-      # ask("Where should the file be saved?", :path => true)
+      #   ask("Where should the file be saved?", :path => true)
       #
       def ask(statement, *args)
         options = args.last.is_a?(Hash) ? args.pop : {}
@@ -93,7 +93,7 @@ class Thor
       # are passed straight to puts (behavior got from Highline).
       #
       # ==== Example
-      # say("I know you knew that.")
+      #   say("I know you knew that.")
       #
       def say(message = "", color = nil, force_new_line = (message.to_s !~ /( |\t)\Z/))
         return if quiet?
@@ -110,7 +110,7 @@ class Thor
       # are passed straight to puts (behavior got from Highline).
       #
       # ==== Example
-      # say_error("error: something went wrong")
+      #   say_error("error: something went wrong")
       #
       def say_error(message = "", color = nil, force_new_line = (message.to_s !~ /( |\t)\Z/))
         return if quiet?

--- a/lib/thor/shell/html.rb
+++ b/lib/thor/shell/html.rb
@@ -67,7 +67,7 @@ class Thor
       # Ask something to the user and receives a response.
       #
       # ==== Example
-      # ask("What is your name?")
+      #   ask("What is your name?")
       #
       # TODO: Implement #ask for Thor::Shell::HTML
       def ask(statement, color = nil)


### PR DESCRIPTION
that put the balise `<code>` inside the generated documentation

### before:
<img width="758" alt="Capture d’écran 2023-11-12 à 15 45 01" src="https://github.com/rails/thor/assets/7428736/6eddd447-b4c4-40ab-b7b8-0ddfe9417b7d">
source: https://www.rubydoc.info/github/wycats/thor/Thor/Shell/Basic:ask

### after:
<img width="1140" alt="Capture d’écran 2023-11-12 à 15 55 04" src="https://github.com/rails/thor/assets/7428736/82c14957-4f2d-44e5-b1cb-2a49b3037c12">

ps : i change "Pluto" by "Neptune" because [Pluto is not a planet anymore](https://loc.gov/rr/scitech//mysteries/pluto.html#:~:text=In%20August%202006%20the%20International,will%20be%20designated%20as%20planets.)