### PR TITLE
Remove String#encode conditional required by Ruby < 2.6

### DIFF
--- a/lib/thor/shell/table_printer.rb
+++ b/lib/thor/shell/table_printer.rb
@@ -102,32 +102,16 @@ class Thor
 
       def truncate(string)
         return string unless @truncate
-        as_unicode do
-          chars = string.chars.to_a
-          if chars.length <= @truncate
-            chars.join
-          else
-            chars[0, @truncate - 3 - @indent].join + "..."
-          end
+        chars = string.chars.to_a
+        if chars.length <= @truncate
+          chars.join
+        else
+          chars[0, @truncate - 3 - @indent].join + "..."
         end
       end
 
       def indentation
         " " * @indent
-      end
-
-      if "".respond_to?(:encode)
-        def as_unicode
-          yield
-        end
-      else
-        def as_unicode
-          old = $KCODE # rubocop:disable Style/GlobalVars
-          $KCODE = "U" # rubocop:disable Style/GlobalVars
-          yield
-        ensure
-          $KCODE = old # rubocop:disable Style/GlobalVars
-        end
       end
     end
   end


### PR DESCRIPTION
As Thor requires Ruby >= 2.6 we don't need to check if String responds to `#encode`, as this is supported since Ruby 1.9.2 at least: https://www.rubydoc.info/stdlib/core/1.9.2/String:encode