### PR TITLE
Avoid loading bundler 2.4.22 that vendorizes thor 1.3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,5 +12,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: ${{ (matrix.ruby_version < '3' && '2.4.21') || 'lagest' }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - run: bundle exec thor spec

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: ${{ (matrix.ruby_version < '3' && '2.4.21') || 'lagest' }}
+        bundler: ${{ (matrix.ruby_version < '3' && '2.4.21') || 'latest' }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - run: bundle exec thor spec


### PR DESCRIPTION
when thor 1.3.0 is vendorized, lcs_diff.rb emits method redefinition warnings as follows:

> .../src/github.com/rails/thor/lib/thor/shell/lcs_diff.rb:6: warning: method redefined; discarding old show_diff
> .../.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/vendor/thor/lib/thor/shell/lcs_diff.rb:6: warning: previous definition of show_diff was here
> .../src/github.com/rails/thor/lib/thor/shell/lcs_diff.rb:21: warning: method redefined; discarding old output_diff_line
> .../.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/vendor/thor/lib/thor/shell/lcs_diff.rb:21: warning: previous definition of output_diff_line was here
> .../src/github.com/rails/thor/lib/thor/shell/lcs_diff.rb:37: warning: method redefined; discarding old diff_lcs_loaded?
> .../.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/bundler-2.4.22/lib/bundler/vendor/thor/lib/thor/shell/lcs_diff.rb:37: warning: previous definition of diff_lcs_loaded? was here