### PR TITLE
Fix documentation of action `copy_file`

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -10,7 +10,6 @@ class Thor
     # destination<String>:: the relative path to the destination root.
     # config<Hash>:: give :verbose => false to not log the status, and
     #                :mode => :preserve, to preserve the file mode from the source.
-
     #
     # ==== Examples
     #


### PR DESCRIPTION
Currently, the documentation of action `copy_file` is slightly broken because of an unnecessary blank line.
<img width="885" alt="image" src="https://github.com/rails/thor/assets/110364235/02ceca24-6bf4-4668-840a-2210cef9167a">
Details: https://www.rubydoc.info/gems/thor/Thor/Actions

This PR removed the blank line to fix the documentation.