### PR TITLE
Preserve Correct Indentation When Uncommenting Lines

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -275,9 +275,8 @@ class Thor
       end
     end
 
-    # Uncomment all lines matching a given regex.  It will leave the space
-    # which existed before the comment hash in tact but will remove any spacing
-    # between the comment hash and the beginning of the line.
+    # Uncomment all lines matching a given regex. Preserves indentation before
+    # the comment hash and removes the hash and any immediate following space.
     #
     # ==== Parameters
     # path<String>:: path of the file to be changed
@@ -291,7 +290,7 @@ class Thor
     def uncomment_lines(path, flag, *args)
       flag = flag.respond_to?(:source) ? flag.source : flag
 
-      gsub_file(path, /^(\s*)#[[:blank:]]*(.*#{flag})/, '\1\2', *args)
+      gsub_file(path, /^(\s*)#[[:blank:]]?(.*#{flag})/, '\1\2', *args)
     end
 
     # Comment all lines matching a given regex.  It will leave the space

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -475,20 +475,26 @@ describe Thor::Actions do
       File.join(destination_root, "doc", "COMMENTER")
     end
 
-    unmodified_comments_file = /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/
+    unmodified_comments_file = /__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/
 
     describe "#uncomment_lines" do
       it "uncomments all matching lines in the file" do
         action :uncomment_lines, "doc/COMMENTER", "green"
-        expect(File.binread(file)).to match(/__start__\n greenblue\n#\n# yellowblue\n#yellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n greenblue\n#\n# yellowblue\n#yellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
 
         action :uncomment_lines, "doc/COMMENTER", "red"
-        expect(File.binread(file)).to match(/__start__\n greenblue\n#\n# yellowblue\nyellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n greenblue\n#\n# yellowblue\nyellowred\n greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
       end
 
       it "correctly uncomments lines with hashes in them" do
         action :uncomment_lines, "doc/COMMENTER", "ind#igo"
-        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  ind#igo\n  #   spaces_between\n__end__/)
+      end
+
+      it "will leave the space which existed before the comment hash in tact" do
+        action :uncomment_lines, "doc/COMMENTER", "ind#igo"
+        action :uncomment_lines, "doc/COMMENTER", "spaces_between"
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  ind#igo\n  ind#igo\n    spaces_between\n__end__/)
       end
 
       it "does not modify already uncommented lines in the file" do
@@ -499,22 +505,22 @@ describe Thor::Actions do
 
       it "does not uncomment the wrong line when uncommenting lines preceded by blank commented line" do
         action :uncomment_lines, "doc/COMMENTER", "yellow"
-        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\nyellowblue\nyellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\nyellowblue\nyellowred\n #greenred\norange\n    purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
       end
     end
 
     describe "#comment_lines" do
       it "comments lines which are not commented" do
         action :comment_lines, "doc/COMMENTER", "orange"
-        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    purple\n  ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
 
         action :comment_lines, "doc/COMMENTER", "purple"
-        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    # purple\n  ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\n# orange\n    # purple\n  ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
       end
 
       it "correctly comments lines with hashes in them" do
         action :comment_lines, "doc/COMMENTER", "ind#igo"
-        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  # ind#igo\n  # ind#igo\n__end__/)
+        expect(File.binread(file)).to match(/__start__\n # greenblue\n#\n# yellowblue\n#yellowred\n #greenred\norange\n    purple\n  # ind#igo\n  # ind#igo\n  #   spaces_between\n__end__/)
       end
 
       it "does not modify already commented lines" do

--- a/spec/fixtures/doc/COMMENTER
+++ b/spec/fixtures/doc/COMMENTER
@@ -8,4 +8,5 @@ orange
     purple
   ind#igo
   # ind#igo
+  #   spaces_between
 __end__


### PR DESCRIPTION
🌈
#### Problem

When using Thor's `uncomment_lines` method to programmatically uncomment lines in YAML files or similar, the method was found to inaccurately handle the preservation of indentation spaces before the comment hash (`#`). Particularly, when uncommenting lines in structured files where indentation is crucial (like YAML files), the original method removed not only the comment hash but also all horizontal whitespace between the hash and the beginning of the content. This behavior led to a disruption in the file's structure and could potentially cause errors when the file was processed or parsed afterward.

For example, in a `.github/workflows/ci.yml` file containing commented-out configuration for Redis:

```yml
# redis:
#   image: redis
#   ports:
#     - 6379:6379
#   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
```

Applying `uncomment_lines` with the previous implementation would result in incorrectly formatted YAML due to the removal of spaces before the content, immediately after the comment hash, disrupting the indentation structure crucial for YAML files.

#### Solution

The proposed change corrects the regex pattern used in the `uncomment_lines` method from `^(\s*)#[[:blank:]]*(.*#{flag})` to `^(\s*)#[[:blank:]]?(.*#{flag})`. This adjustment ensures that:

- The leading indentation before the comment hash is preserved.
- Only the first space or tab (if any) right after the comment hash is removed, along with the hash itself.

This means that the indentation structure of the uncommented lines remains intact, preserving the file's integrity and adherence to YAML or other structured file formats' syntax requirements.

#### Impact

This change significantly improves the utility of the `uncomment_lines` method for Rails developers and others using Thor for automation scripts, particularly when working with YAML files for CI/CD pipelines, configurations, etc. It ensures that the uncommented lines blend seamlessly into the document's structure without introducing syntax errors or misinterpretations by parsers.