### PR TITLE
Document the '--skip-' option for boolean options.

### DIFF
--- a/lib/thor/parser/option.rb
+++ b/lib/thor/parser/option.rb
@@ -89,8 +89,8 @@ class Thor
 
       sample = "[#{sample}]".dup unless required?
 
-      if boolean?
-        sample << ", [#{dasherize('no-' + human_name)}]" unless (name == "force") || name.match(/\Ano[\-_]/)
+      if boolean? && name != "force" && !name.match(/\A(no|skip)[\-_]/)
+        sample << ", [#{dasherize('no-' + human_name)}], [#{dasherize('skip-' + human_name)}]"
       end
 
       aliases_for_usage.ljust(padding) + sample

--- a/lib/thor/parser/options.rb
+++ b/lib/thor/parser/options.rb
@@ -250,7 +250,8 @@ class Thor
       @parsing_options
     end
 
-    # Parse boolean values which can be given as --foo=true, --foo or --no-foo.
+    # Parse boolean values which can be given as --foo=true or --foo for true values, or
+    # --foo=false, --no-foo or --skip-foo for false values.
     #
     def parse_boolean(switch)
       if current_is_value?

--- a/spec/parser/option_spec.rb
+++ b/spec/parser/option_spec.rb
@@ -218,11 +218,11 @@ describe Thor::Option do
     end
 
     it "returns usage for boolean types" do
-      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo]")
+      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo], [--skip-foo]")
     end
 
     it "does not use padding when no aliases are given" do
-      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo]")
+      expect(parse(:foo, :boolean).usage).to eq("[--foo], [--no-foo], [--skip-foo]")
     end
 
     it "documents a negative option when boolean" do
@@ -231,6 +231,9 @@ describe Thor::Option do
 
     it "does not document a negative option for a negative boolean" do
       expect(parse(:'no-foo', :boolean).usage).not_to include("[--no-no-foo]")
+      expect(parse(:'no-foo', :boolean).usage).not_to include("[--skip-no-foo]")
+      expect(parse(:'skip-foo', :boolean).usage).not_to include("[--no-skip-foo]")
+      expect(parse(:'skip-foo', :boolean).usage).not_to include("[--skip-skip-foo]")
     end
 
     it "does not document a negative option for an underscored negative boolean" do
@@ -261,7 +264,7 @@ describe Thor::Option do
       end
 
       it "does not negate the aliases" do
-        expect(parse([:foo, "-f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo]")
+        expect(parse([:foo, "-f", "-b"], :boolean).usage).to eq("-f, -b, [--foo], [--no-foo], [--skip-foo]")
       end
 
       it "normalizes the aliases" do


### PR DESCRIPTION
When specifying a boolean option `foo`, Thor will accept `--skip-foo` as an options (the same as `--no-foo`). This behaviour was previously undocumented.

This PR updates the documentation in the repo and also the `usage` method to make this feature more discoverable.