### PR TITLE
feat: support `gsub_file` erroring if gsub doesn't change anything, and add `gsub_file!`

### DIFF
--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -248,7 +248,8 @@ class Thor
     # path<String>:: path of the file to be changed
     # flag<Regexp|String>:: the regexp or string to be replaced
     # replacement<String>:: the replacement, can be also given as a block
-    # config<Hash>:: give :verbose => false to not log the status, and
+    # config<Hash>:: give :verbose => false to not log the status,
+    #                :error_on_no_change => true to raise an error if the file does not change, and
     #                :force => true, to force the replacement regardless of runner behavior.
     #
     # ==== Example
@@ -269,7 +270,12 @@ class Thor
 
       unless options[:pretend]
         content = File.binread(path)
-        content.gsub!(flag, *args, &block)
+        success = content.gsub!(flag, *args, &block)
+
+        if success.nil? && config.fetch(:error_on_no_change, false)
+          raise Thor::Error, "The content of #{path} did not change"
+        end
+
         File.open(path, "wb") { |file| file.write(content) }
       end
     end

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -254,9 +254,9 @@ class Thor
     #
     # ==== Example
     #
-    #   gsub_file 'app/controllers/application_controller.rb', /#\s*(filter_parameter_logging :password)/, '\1'
+    #   gsub_file! 'app/controllers/application_controller.rb', /#\s*(filter_parameter_logging :password)/, '\1'
     #
-    #   gsub_file 'README', /rake/, :green do |match|
+    #   gsub_file! 'README', /rake/, :green do |match|
     #     match << " no more. Use thor!"
     #   end
     #

--- a/lib/thor/actions/file_manipulation.rb
+++ b/lib/thor/actions/file_manipulation.rb
@@ -242,6 +242,32 @@ class Thor
       insert_into_file(path, *(args << config), &block)
     end
 
+    # Run a regular expression replacement on a file, raising an error if the
+    # contents of the file are not changed.
+    #
+    # ==== Parameters
+    # path<String>:: path of the file to be changed
+    # flag<Regexp|String>:: the regexp or string to be replaced
+    # replacement<String>:: the replacement, can be also given as a block
+    # config<Hash>:: give :verbose => false to not log the status, and
+    #                :force => true, to force the replacement regardless of runner behavior.
+    #
+    # ==== Example
+    #
+    #   gsub_file 'app/controllers/application_controller.rb', /#\s*(filter_parameter_logging :password)/, '\1'
+    #
+    #   gsub_file 'README', /rake/, :green do |match|
+    #     match << " no more. Use thor!"
+    #   end
+    #
+    def gsub_file!(path, flag, *args, &block)
+      config = args.last.is_a?(Hash) ? args.pop : {}
+
+      config[:error_on_no_change] = true
+
+      gsub_file(path, flag, *args, config, &block)
+    end
+
     # Run a regular expression replacement on a file.
     #
     # ==== Parameters

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -318,6 +318,26 @@ describe Thor::Actions do
         it "does not log status if required" do
           expect(action(:gsub_file, file, "__", verbose: false) { |match| match * 2 }).to be_empty
         end
+
+        it "does not care if the file contents did not change" do
+          action :gsub_file, "doc/README", "___start___", "START"
+          expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
+        end
+
+        context "with error_on_no_change" do
+          it "replaces the content in the file" do
+            action :gsub_file, "doc/README", "__start__", "START", error_on_no_change: true
+            expect(File.binread(file)).to eq("START\nREADME\n__end__\n")
+          end
+
+          it "raises if the file contents did not change" do
+            expect do
+              action :gsub_file, "doc/README", "___start___", "START", error_on_no_change: true
+            end.to raise_error(Thor::Error, "The content of #{destination_root}/doc/README did not change")
+
+            expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
+          end
+        end
       end
 
       context "with revoke behavior" do

--- a/spec/actions/file_manipulation_spec.rb
+++ b/spec/actions/file_manipulation_spec.rb
@@ -421,21 +421,6 @@ describe Thor::Actions do
           action :gsub_file, "doc/README", "___start___", "START"
           expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
         end
-
-        context "with error_on_no_change" do
-          it "replaces the content in the file" do
-            action :gsub_file, "doc/README", "__start__", "START", error_on_no_change: true
-            expect(File.binread(file)).to eq("START\nREADME\n__end__\n")
-          end
-
-          it "raises if the file contents did not change" do
-            expect do
-              action :gsub_file, "doc/README", "___start___", "START", error_on_no_change: true
-            end.to raise_error(Thor::Error, "The content of #{destination_root}/doc/README did not change")
-
-            expect(File.binread(file)).to eq("__start__\nREADME\n__end__\n")
-          end
-        end
       end
 
       context "with revoke behavior" do


### PR DESCRIPTION
🌈

---

This is a straw-person solution for #874  - overall I think it's not bad but expect changes to be requested; in particular, the option name is pretty verbose so happy if someone wants to suggest an alternative though to me really its about having `gsub_file!`.

A bonus to this is that anything using `gsub_file` also supports this behaviour such as `comment_lines` and `uncomment_lines` - I think it would be nice to have bang versions of such methods too but want to get the core behaviour/implementation nailed down first.

Resolves #874