### PR TITLE
Correctly identify hyphenated and alias command names

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -439,6 +439,17 @@ class Thor
       command && disable_required_check.include?(command.name.to_sym)
     end
 
+    # Checks if a specified command exists.
+    #
+    # ==== Parameters
+    # command_name<String>:: The name of the command to check for existence.
+    #
+    # ==== Returns
+    # Boolean:: +true+ if the command exists, +false+ otherwise.
+    def command_exists?(command_name) #:nodoc:
+      commands.keys.include?(normalize_command_name(command_name))
+    end
+
   protected
 
     # Returns this class exclusive options array set.

--- a/lib/thor/group.rb
+++ b/lib/thor/group.rb
@@ -211,6 +211,17 @@ class Thor::Group
       raise error, msg
     end
 
+    # Checks if a specified command exists.
+    #
+    # ==== Parameters
+    # command_name<String>:: The name of the command to check for existence.
+    #
+    # ==== Returns
+    # Boolean:: +true+ if the command exists, +false+ otherwise.
+    def command_exists?(command_name) #:nodoc:
+      commands.keys.include?(command_name)
+    end
+
   protected
 
     # The method responsible for dispatching given the args.

--- a/lib/thor/util.rb
+++ b/lib/thor/util.rb
@@ -133,7 +133,7 @@ class Thor
           *pieces, command  = namespace.split(":")
           namespace = pieces.join(":")
           namespace = "default" if namespace.empty?
-          klass = Thor::Base.subclasses.detect { |thor| thor.namespace == namespace && thor.commands.keys.include?(command) }
+          klass = Thor::Base.subclasses.detect { |thor| thor.namespace == namespace && thor.command_exists?(command) }
         end
         unless klass # look for a Thor::Group with the right name
           klass = Thor::Util.find_by_namespace(namespace)

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -264,12 +264,15 @@ end
 class Apple < Thor
   namespace :fruits
   desc 'apple', 'apple'; def apple; end
+  desc 'rotten-apple', 'rotten apple'; def rotten_apple; end
+  map "ra" => :rotten_apple
 end
 
 class Pear < Thor
   namespace :fruits
   desc 'pear', 'pear'; def pear; end
 end
+
 class MyClassOptionScript < Thor
   class_option :free
 

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -186,6 +186,16 @@ describe Thor::Group do
     end
   end
 
+  describe "#command_exists?" do
+    it "returns true for a command that is defined in the class" do
+      expect(MyCounter.command_exists?("one")).to be true
+    end
+
+    it "returns false for a command that is not defined in the class" do
+      expect(MyCounter.command_exists?("zero")).to be false
+    end
+  end
+
   describe "edge-cases" do
     it "can handle boolean options followed by arguments" do
       klass = Class.new(Thor::Group) do

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -340,6 +340,18 @@ describe Thor do
     end
   end
 
+  describe "#command_exists?" do
+    it "returns true for a command that is defined in the class" do
+      expect(MyScript.command_exists?("zoo")).to be true
+      expect(MyScript.command_exists?("name-with-dashes")).to be true
+      expect(MyScript.command_exists?("animal_prison")).to be true
+    end
+
+    it "returns false for a command that is not defined in the class" do
+      expect(MyScript.command_exists?("animal_heaven")).to be false
+    end
+  end
+
   describe "#map" do
     it "calls the alias of a method if one is provided" do
       expect(MyScript.start(%w(-T fish))).to eq(%w(fish))

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -114,6 +114,14 @@ describe Thor::Util do
       expect(Thor::Util.find_class_and_command_by_namespace("fruits:apple")).to eq([Apple, "apple"])
       expect(Thor::Util.find_class_and_command_by_namespace("fruits:pear")).to eq([Pear, "pear"])
     end
+
+    it "returns correct Thor class and the command name with hypen when shared namespaces" do
+      expect(Thor::Util.find_class_and_command_by_namespace("fruits:rotten-apple")).to eq([Apple, "rotten-apple"])
+    end
+
+    it "returns correct Thor class and the associated alias command name when shared namespaces" do
+      expect(Thor::Util.find_class_and_command_by_namespace("fruits:ra")).to eq([Apple, "ra"])
+    end
   end
 
   describe "#thor_classes_in" do


### PR DESCRIPTION
Fixes https://github.com/rails/thor/issues/868

Problem:
After version 1.3.0, invoking commands with hyphenated and alias names does not function as expected.

Given a Thor class definition as follows:
```
class Test < Thor
  desc "foo-bar", "an example task"
  def foo_bar
    puts "I'm a thor task!"
  end

  map "fb" => :foo_bar 
end
```

Each command results in the following.

```
% thor test:foo_bar
I'm a thor task!
```

```
% thor test:foo-bar
Commands:
  thor test:foo-bar         # an example task
  thor test:help [COMMAND]  # Describe available commands or one specific command
```

```
% thor test:fb
Commands:
  thor test:foo-bar         # an example task
  thor test:help [COMMAND]  # Describe available commands or one specific command
```

This PR addresses the issue by implementing a fix in the `find_class_and_command_by_namespace` method, ensuring that it correctly identifies both hyphenated command names and their aliases.