### PR TITLE
Address `warning: literal string will be frozen in the future`

### DIFF
--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -318,7 +318,7 @@ describe Thor::Base do
     end
 
     it "suggests commands that are similar if there is a typo" do
-      expected = "Could not find command \"paintz\" in \"barn\" namespace.\n"
+      expected = "Could not find command \"paintz\" in \"barn\" namespace.\n".dup
       expected << "Did you mean?  \"paint\"\n" if Thor::Correctable
 
       expect(capture(:stderr) { Barn.start(%w(paintz)) }).to eq(expected)

--- a/spec/parser/options_spec.rb
+++ b/spec/parser/options_spec.rb
@@ -117,7 +117,7 @@ describe Thor::Options do
       create foo: "baz", bar: :required
       parse("--bar", "baz", "--baz", "unknown")
 
-      expected = "Unknown switches \"--baz\""
+      expected = "Unknown switches \"--baz\"".dup
       expected << "\nDid you mean?  \"--bar\"" if Thor::Correctable
 
       expect { check_unknown! }.to raise_error(Thor::UnknownArgumentError) do |error|


### PR DESCRIPTION
This commit addresses the following warnings.

- Steps to reproduce:
```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-26T13:20:34Z master 484ea00d2e) +PRISM [x86_64-linux]
$ RUBYOPT="--debug-frozen-string-literal" bundle exec thor spec
```

- Warnings addressed by this commit:
```
/path/to/thor/spec/base_spec.rb:322: warning: literal string will be frozen in the future
/path/to/thor/spec/base_spec.rb:321: info: the string was created here
```

```
/path/to/thor/spec/parser/options_spec.rb:121: warning: literal string will be frozen in the future
/path/to/thor/spec/parser/options_spec.rb:120: info: the string was created here
```

Refer to:
https://bugs.ruby-lang.org/issues/20205
https://github.com/ruby/ruby/pull/11893