### PR TITLE
Support Ruby 3.4 `Hash#inspect` change

### DIFF
--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -767,7 +767,7 @@ HELP
         Class.new(Thor) do
           method_option loud: true, type: :boolean
         end
-      end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")
+      end.to raise_error(ArgumentError, "Expected a Symbol or String, got #{{loud: true, type: :boolean}}")
     end
 
     it "class_option raises an ArgumentError if name is not a Symbol or String" do
@@ -775,7 +775,7 @@ HELP
         Class.new(Thor) do
           class_option loud: true, type: :boolean
         end
-      end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")
+      end.to raise_error(ArgumentError, "Expected a Symbol or String, got #{{loud: true, type: :boolean}}")
     end
 
     it "passes through unknown options" do


### PR DESCRIPTION
This commit addresses the following failures against Ruby 3.4.0dev that includes https://github.com/ruby/ruby/pull/10924 . This commit also passes specs againt Ruby 3.3.5.

```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-26T13:20:34Z master 484ea00d2e) +PRISM [x86_64-linux]
$ bundle exec rspec ./spec/thor_spec.rb
Source locally installed gems is ignoring #<Bundler::StubSpecification name=prism version=1.0.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=json version=2.7.2 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=google-protobuf version=4.27.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=cgi version=0.4.1 platform=ruby> because it is missing extensions
rdoc was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add rdoc to your Gemfile or gemspec to silence this warning.
........................................................................................................FF.........

Failures:

  1) Thor edge-cases method_option raises an ArgumentError if name is not a Symbol or String
     Failure/Error:
       expect do
         Class.new(Thor) do
           method_option loud: true, type: :boolean
         end
       end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")

       expected ArgumentError with "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}", got #<ArgumentError: Expected a Symbol or String, got {loud: true, type: :boolean}> with backtrace:
         # ./lib/thor.rb:165:in 'Thor.method_option'
         # ./spec/thor_spec.rb:768:in 'block (5 levels) in <top (required)>'
         # ./spec/thor_spec.rb:767:in 'Class#initialize'
         # ./spec/thor_spec.rb:767:in 'Class#new'
         # ./spec/thor_spec.rb:767:in 'block (4 levels) in <top (required)>'
         # ./spec/thor_spec.rb:770:in 'block (3 levels) in <top (required)>'
     # ./spec/thor_spec.rb:770:in 'block (3 levels) in <top (required)>'

  2) Thor edge-cases class_option raises an ArgumentError if name is not a Symbol or String
     Failure/Error:
       expect do
         Class.new(Thor) do
           class_option loud: true, type: :boolean
         end
       end.to raise_error(ArgumentError, "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}")

       expected ArgumentError with "Expected a Symbol or String, got {:loud=>true, :type=>:boolean}", got #<ArgumentError: Expected a Symbol or String, got {loud: true, type: :boolean}> with backtrace:
         # ./lib/thor/base.rb:330:in 'Thor::Base::ClassMethods#class_option'
         # ./spec/thor_spec.rb:776:in 'block (5 levels) in <top (required)>'
         # ./spec/thor_spec.rb:775:in 'Class#initialize'
         # ./spec/thor_spec.rb:775:in 'Class#new'
         # ./spec/thor_spec.rb:775:in 'block (4 levels) in <top (required)>'
         # ./spec/thor_spec.rb:778:in 'block (3 levels) in <top (required)>'
     # ./spec/thor_spec.rb:778:in 'block (3 levels) in <top (required)>'

Finished in 0.0627 seconds (files took 0.26431 seconds to load)
115 examples, 2 failures

Failed examples:

rspec ./spec/thor_spec.rb:765 # Thor edge-cases method_option raises an ArgumentError if name is not a Symbol or String
rspec ./spec/thor_spec.rb:773 # Thor edge-cases class_option raises an ArgumentError if name is not a Symbol or String

Coverage report generated for RSpec to /home/yahonda/src/github.com/rails/thor/coverage.
Line Coverage: 67.3% (1490 / 2214)
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Couldn't find a repository matching this job.
Coverage is at 67.3%.
Coverage report sent to Coveralls.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
$
```

Refer to:
https://github.com/ruby/ruby/pull/10924
https://bugs.ruby-lang.org/issues/20433