### PR TITLE
Lazily load YAML

### DIFF
--- a/lib/thor/runner.rb
+++ b/lib/thor/runner.rb
@@ -1,7 +1,6 @@
 require_relative "../thor"
 require_relative "group"
 
-require "yaml"
 require "digest/sha2"
 require "pathname"
 
@@ -195,6 +194,7 @@ private
   def thor_yaml
     @thor_yaml ||= begin
       yaml_file = File.join(thor_root, "thor.yml")
+      require "yaml"
       yaml = YAML.load_file(yaml_file) if File.exist?(yaml_file)
       yaml || {}
     end


### PR DESCRIPTION
This avoids errors when Bundler is activated _after_ thor, and a different version of YAML (or dependencies of it, like stringio) is included in the Gemfile/Gemfile.lock than the one that thor activates internally.