### PR TITLE
Use secure thor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage and documentation
 Please see the [wiki][] for basic usage and other documentation on using Thor. You can also check out the [official homepage][homepage].
 
 [wiki]: https://github.com/rails/thor/wiki
-[homepage]: http://whatisthor.com/
+[homepage]: https://www.whatisthor.com/
 
 Contributing
 ------------


### PR DESCRIPTION
The link to whatisthor.com is insecure: `http://whatisthor.com/` 

It should be the secure version.

![2024-12-16_15-25](https://github.com/user-attachments/assets/5d63ab5e-5eb1-4597-9942-3c1ac13bcaa7)
