### PR TITLE
fix: Unsafe shell command constructed from library input

### DIFF
--- a/lib/thor/shell/basic.rb
+++ b/lib/thor/shell/basic.rb
@@ -372,7 +372,7 @@ class Thor
         Tempfile.open([File.basename(destination), File.extname(destination)], File.dirname(destination)) do |temp|
           temp.write content
           temp.rewind
-          system %(#{merge_tool} "#{temp.path}" "#{destination}")
+          system(merge_tool, temp.path, destination)
         end
       end
 

--- a/spec/actions/create_file_spec.rb
+++ b/spec/actions/create_file_spec.rb
@@ -142,7 +142,7 @@ describe Thor::Actions::CreateFile do
           create_file("doc/config.rb")
           allow(@base.shell).to receive(:merge_tool).and_return("meld")
           expect(Thor::LineEditor).to receive(:readline).and_return("m")
-          expect(@base.shell).to receive(:system).with(/meld/)
+          expect(@base.shell).to receive(:system).with("meld", /doc\/config\.rb/, /doc\/config\.rb/)
           invoke!
         end
       end

--- a/spec/shell/basic_spec.rb
+++ b/spec/shell/basic_spec.rb
@@ -553,14 +553,14 @@ TABLE
       it "invokes the merge tool" do
         allow(shell).to receive(:merge_tool).and_return("meld")
         expect(Thor::LineEditor).to receive(:readline).and_return("m")
-        expect(shell).to receive(:system).with(/meld/)
+        expect(shell).to receive(:system).with("meld", /foo/, "foo")
         capture(:stdout) { shell.file_collision("foo") {} }
       end
 
       it "invokes the merge tool that specified at ENV['THOR_MERGE']" do
         allow(ENV).to receive(:[]).with("THOR_MERGE").and_return("meld")
         expect(Thor::LineEditor).to receive(:readline).and_return("m")
-        expect(shell).to receive(:system).with(/meld/)
+        expect(shell).to receive(:system).with("meld", /foo/, "foo")
         capture(:stdout) { shell.file_collision("foo") {} }
       end
 


### PR DESCRIPTION
Requested at from [GHSA-9497-wr55-jwhj](https://github.com/rubygems/rubygems/security/advisories/GHSA-9497-wr55-jwhj)

Dynamically constructing a shell command with inputs from exported functions may inadvertently change the meaning of the shell command. Clients using the exported function may use inputs containing characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

