### PR TITLE
Hidden commands should not make an invocation ambiguous

### DIFF
--- a/lib/thor.rb
+++ b/lib/thor.rb
@@ -625,7 +625,7 @@ class Thor
     # alias name.
     def find_command_possibilities(meth)
       len = meth.to_s.length
-      possibilities = all_commands.merge(map).keys.select { |n| meth == n[0, len] }.sort
+      possibilities = all_commands.reject {|k, v| v.is_a?(HiddenCommand) }.merge(map).keys.select { |n| meth == n[0, len] }.sort
       unique_possibilities = possibilities.map { |k| map[k] || k }.uniq
 
       if possibilities.include?(meth)

--- a/spec/fixtures/script.thor
+++ b/spec/fixtures/script.thor
@@ -129,6 +129,16 @@ Linebreaks preserved
     true
   end
 
+  desc "potentially_ambiguous", "not really ambiguous because conflicting command is hidden"
+  def potentially_ambiguous
+    true
+  end
+
+  desc "potentially_ambiguous_but_hidden", "not considered for ambiguous check because it's hidden", hide: true
+  def potentially_ambiguous_but_hidden
+    false
+  end
+
   private
 
     def method_missing(meth, *args)

--- a/spec/thor_spec.rb
+++ b/spec/thor_spec.rb
@@ -522,6 +522,10 @@ Usage: "thor scripts:arities:multiple_usages ARG --foo"
       it "invokes an alias" do
         expect(MyScript.start(%w(animal_pri))).to eq(MyScript.start(%w(zoo)))
       end
+
+      it "invokes a command, even when there's a hidden command that makes invokation ambiguous" do
+        expect(MyScript.start(%w(potentially_))).to eq(MyScript.start(%w(potentially_ambiguous)))
+      end
     end
 
     context "when the user enters an ambiguous substring of a command" do


### PR DESCRIPTION
If a command is hidden from help, I think it should not be considered when checking if an invocation is ambiguous.