### PR TITLE
Set frozen_string_literal: true in colors.rb

### DIFF
--- a/lib/thor/shell/color.rb
+++ b/lib/thor/shell/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "basic"
 require_relative "lcs_diff"
 


### PR DESCRIPTION
We should use frozen string literals in this file. There are a bunch of string literals in constants that should be constant.